### PR TITLE
Enforce building warnings as errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,10 +166,8 @@ AC_ARG_ENABLE(oclblender,
 AM_CONDITIONAL(BUILD_OCL_BLENDER,
     [test "x$enable_oclblender" = "xyes"])
 
-
-
-dnl : ${CFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
-dnl : ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
+AC_SUBST([AM_CFLAGS], ["-g -O2 -Wall -Wno-unused-function -Wno-cpp -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["-g -O2 -Wall -Wno-unused-function -Wno-cpp -Wno-missing-braces -Werror"])
 
 # Checks for programs.
 AC_DISABLE_STATIC

--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -23,7 +23,14 @@
 #include "common/VaapiUtils.h"
 
 #if __ENABLE_MD5__
+// including bsd/md5.h produces a warning with __bounded__ attribute,
+// libyami-utils chooses to ignore this particular warning by pushing the
+// current environment, ignoring attributes and then poping to restore the
+// environment.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #include <bsd/md5.h>
+#pragma GCC diagnostic pop
 #endif
 
 #ifdef __ENABLE_X11__


### PR DESCRIPTION
Warnings are treated as errors with this patch.  It follows libyami way and corrects warnings found so far. If more warnings are seen  please report back. 