### PR TITLE
encoder_h264:add parameter Cabac Dct8x8 and DeblockFilter

### DIFF
--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -17,6 +17,7 @@
 #include "config.h"
 #endif
 #include "vppoutputencode.h"
+#include "YamiVersion.h"
 
 EncodeParams::EncodeParams()
     : rcMode(RATE_CONTROL_CQP)
@@ -28,6 +29,11 @@ EncodeParams::EncodeParams()
     , numRefFrames(1)
     , idrInterval(0)
     , codec("AVC")
+    , enableCabac(true)
+    , enableDct8x8(false)
+    , enableDeblockFilter(true)
+    , deblockAlphaOffsetDiv2(2)
+    , deblockBetaOffsetDiv2(2)
 {
     /*nothing to do*/
 }
@@ -70,7 +76,7 @@ void VppOutputEncode::initOuputBuffer()
 static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
                            int width, int height, const EncodeParams* encParam)
 {
-       //configure encoding parameters
+    //configure encoding parameters
     VideoParamsCommon encVideoParams;
     encVideoParams.size = sizeof(VideoParamsCommon);
     encoder->getParameters(VideoParamsTypeCommon, &encVideoParams);
@@ -88,7 +94,6 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encVideoParams.rcParams.initQP = encParam->initQp;
     encVideoParams.rcMode = encParam->rcMode;
     encVideoParams.numRefFrames = encParam->numRefFrames;
-
     encVideoParams.size = sizeof(VideoParamsCommon);
     encoder->setParameters(VideoParamsTypeCommon, &encVideoParams);
 
@@ -98,6 +103,17 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encoder->getParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
     encVideoParamsAVC.idrInterval = encParam->idrInterval;
     encVideoParamsAVC.size = sizeof(VideoParamsAVC);
+#if YAMI_CHECK_API_VERSION(0, 2, 1)
+    encVideoParamsAVC.enableCabac = encParam->enableCabac;
+    encVideoParamsAVC.enableDct8x8 = encParam->enableDct8x8;
+    encVideoParamsAVC.enableDeblockFilter = encParam->enableDeblockFilter;
+    encVideoParamsAVC.deblockAlphaOffsetDiv2 = encParam->deblockAlphaOffsetDiv2;
+    encVideoParamsAVC.deblockBetaOffsetDiv2 = encParam->deblockBetaOffsetDiv2;
+#else
+    ERROR("version num of YamiAPI should be greater than or enqual to %s, \n%s "
+    , "0.2.1"
+    , "or enableCabac, enableDct8x8 and enableDeblockFilter will use the default value");
+#endif
     encoder->setParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
 
     VideoConfigAVCStreamFormat streamFormat;

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -38,6 +38,11 @@ public:
     int32_t numRefFrames;
     int32_t idrInterval;
     string codec;
+    bool enableCabac;
+    bool enableDct8x8;
+    bool enableDeblockFilter;
+    int8_t deblockAlphaOffsetDiv2; //same as slice_alpha_c0_offset_div2 defined in h264 spec 7.4.3
+    int8_t deblockBetaOffsetDiv2; //same as slice_beta_offset_div2 defined in h264 spec 7.4.3
 };
 
 class TranscodeParams

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -49,6 +49,11 @@ static void print_help(const char* app)
     printf("   --intraperiod <Intra frame period(default 30)> optional\n");
     printf("   --refnum <number of referece frames(default 1)> optional\n");
     printf("   --idrinterval <AVC/HEVC IDR frame interval(default 0)> optional\n");
+    printf("   --enablecabac <AVC is to use CABAC or not in Main Profile (default true)> optional\n");
+    printf("   --enabledct8x8 <AVC is to use DCT8x8 transform or not in High Profile (default false)> optional\n");
+    printf("   --enabledeblockfilter <AVC is to use Deblock filter or not (default true)> optional\n");
+    printf("   --deblockalphadiv2 <AVC Alpha offset of debloking filter divided 2 (default 2)> optional\n");
+    printf("   --deblockbetadiv2 <AVC Beta offset of debloking filter divided 2 (default 2)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -77,6 +82,11 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"intraperiod", required_argument, NULL, 0 },
         {"refnum", required_argument, NULL, 0 },
         {"idrinterval", required_argument, NULL, 0 },
+        {"enablecabac", required_argument, NULL, 0},
+        {"enabledct8x8", required_argument, NULL, 0},
+        {"enabledeblockfilter", required_argument, NULL, 0},
+        {"deblockalphadiv2", required_argument, NULL, 0},
+        {"deblockbetadiv2", required_argument, NULL, 0},
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -140,6 +150,21 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                 case 6:
                     para.m_encParams.idrInterval = atoi(optarg);
                     break;
+                case 7:
+                    para.m_encParams.enableCabac = strncasecmp(optarg, "false", 5) != 0;
+                    break;
+                case 8:
+                    para.m_encParams.enableDct8x8 = strncasecmp(optarg, "true", 4) == 0;
+                    break;
+                case 9:
+                    para.m_encParams.enableDeblockFilter = strncasecmp(optarg, "false", 5) != 0;
+                    break;
+                case 10:
+                    para.m_encParams.deblockAlphaOffsetDiv2 = atoi(optarg);
+                    break;
+                case 11:
+                    para.m_encParams.deblockBetaOffsetDiv2 = atoi(optarg);
+                    break;
             }
         }
     }
@@ -195,7 +220,6 @@ SharedPtr<VppInput> createInput(TranscodeParams& para, const SharedPtr<VADisplay
 
 SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADisplay>& display)
 {
-
     SharedPtr<VppOutput> output = VppOutput::create(para.outputFileName.c_str(), para.fourcc, para.oWidth, para.oHeight);
     SharedPtr<VppOutputFile> outputFile = std::tr1::dynamic_pointer_cast<VppOutputFile>(output);
     if (outputFile) {


### PR DESCRIPTION
the following patches:
0001-encoder_h264-add-parameter-Cabac-Dct8x8-and-DeblockF.patch
0002-encoder_h264-fix-the-bug-of-AVC-deblock.patch 
are the related files in libyami, apache branch.
