### PR TITLE
We should not abort all deocde process if it's only non-fatal error returned.

### DIFF
--- a/tests/vppinputdecode.cpp
+++ b/tests/vppinputdecode.cpp
@@ -85,10 +85,8 @@ bool VppInputDecode::read(SharedPtr<VideoFrame>& frame)
             status = m_decoder->decode(&inputBuffer);
             m_eos = true;
         }
-        if (status != DECODE_SUCCESS) { /*failed, need to flush*/
-            inputBuffer.data = NULL;
-            inputBuffer.size = 0;
-            m_decoder->decode(&inputBuffer);
+        if (status < 0) { /* fatal error */
+            fprintf(stderr, "got fatal error %d\n", status);
             m_error = true;
         }
     }

--- a/tests/vppinputdecodecapi.cpp
+++ b/tests/vppinputdecodecapi.cpp
@@ -89,10 +89,8 @@ bool VppInputDecodeCapi::read(SharedPtr<VideoFrame>& frame)
             decodeDecode(m_decoder, &inputBuffer);
             m_eos = true;
         }
-        if (status != DECODE_SUCCESS) { /*failed, need to flush*/
-            inputBuffer.data = NULL;
-            inputBuffer.size = 0;
-            decodeDecode(m_decoder, &inputBuffer);
+        if (status < 0) { /* fatal error */
+            fprintf(stderr, "got fatal error %d\n", status);
             m_error = true;
         }
     }


### PR DESCRIPTION
Bitstream have error bits some time. We can skip decode the frame. But we'd better do not abort entire deocde process. So we ignore not-fatal error.