### PR TITLE
yamitranscode: implement I/P/B QP setting on CQP mode

### DIFF
--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -34,6 +34,8 @@ EncodeParams::EncodeParams()
     , enableDeblockFilter(true)
     , deblockAlphaOffsetDiv2(2)
     , deblockBetaOffsetDiv2(2)
+    , diffQPIP(0)
+    , diffQPIB(0)
 {
     /*nothing to do*/
 }
@@ -92,6 +94,8 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encVideoParams.ipPeriod = encParam->ipPeriod;
     encVideoParams.rcParams.bitRate = encParam->bitRate;
     encVideoParams.rcParams.initQP = encParam->initQp;
+    encVideoParams.rcParams.diffQPIP = encParam->diffQPIP;
+    encVideoParams.rcParams.diffQPIB = encParam->diffQPIB;
     encVideoParams.rcMode = encParam->rcMode;
     encVideoParams.numRefFrames = encParam->numRefFrames;
     encVideoParams.size = sizeof(VideoParamsCommon);

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -43,6 +43,8 @@ public:
     bool enableDeblockFilter;
     int8_t deblockAlphaOffsetDiv2; //same as slice_alpha_c0_offset_div2 defined in h264 spec 7.4.3
     int8_t deblockBetaOffsetDiv2; //same as slice_beta_offset_div2 defined in h264 spec 7.4.3
+    int8_t diffQPIP;// P frame qp minus initQP
+    int8_t diffQPIB;// B frame qp minus initQP
 };
 
 class TranscodeParams

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -54,6 +54,8 @@ static void print_help(const char* app)
     printf("   --enabledeblockfilter <AVC is to use Deblock filter or not (default true)> optional\n");
     printf("   --deblockalphadiv2 <AVC Alpha offset of debloking filter divided 2 (default 2)> optional\n");
     printf("   --deblockbetadiv2 <AVC Beta offset of debloking filter divided 2 (default 2)> optional\n");
+    printf("   --qpip <qp difference between adjacent I/P (default 0)> optional\n");
+    printf("   --qpib <qp difference between adjacent I/B (default 0)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -87,6 +89,8 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"enabledeblockfilter", required_argument, NULL, 0},
         {"deblockalphadiv2", required_argument, NULL, 0},
         {"deblockbetadiv2", required_argument, NULL, 0},
+        {"qpip", required_argument, NULL, 0 },
+        {"qpib", required_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -164,6 +168,12 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                     break;
                 case 11:
                     para.m_encParams.deblockBetaOffsetDiv2 = atoi(optarg);
+                    break;
+                case 12:
+                    para.m_encParams.diffQPIP = atoi(optarg);
+                    break;
+                case 13:
+                    para.m_encParams.diffQPIB = atoi(optarg);
                     break;
             }
         }


### PR DESCRIPTION
add --ipqp and --pbqp,
the difference between I and B is the sum of --ipqp and --pbqp.

Signed-off-by: wudping <dongpingx.wu@intel.com>