### PR TITLE
configure.ac: check libyami version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,7 +260,7 @@ if test "$enable_md5" = "yes"; then
         [])
 fi
 
-PKG_CHECK_MODULES([LIBYAMI], [libyami])
+PKG_CHECK_MODULES([LIBYAMI], [libyami >= 0.2.2])
 
 AM_CONDITIONAL(ENABLE_MD5, test "x$enable_md5" = "xyes")
 


### PR DESCRIPTION
To avoid add nasty version check in source code like this
https://github.com/01org/libyami-utils/blob/master/tests/vpp.cpp#L212.
We’d better check min libyami version number in configure.ac.
This will break automatic “git bisect”.However, it will keep our code more tidy.