### PR TITLE
Vp9enc enabled on yamiencode

### DIFF
--- a/tests/encode.cpp
+++ b/tests/encode.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     if (!process_cmdline(argc, argv))
         return -1;
 
-    DEBUG("inputFourcc: %.4s", (char*)(&(inputFourcc)));
+    DEBUG("inputFourcc: %.4s codec is %s", (char*)(&(inputFourcc)), codec);
     input = EncodeInput::create(inputFileName, inputFourcc, videoWidth, videoHeight);
     if (!input) {
         fprintf (stderr, "fail to init input stream\n");
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
     videoWidth = input->getWidth();
     videoHeight = input->getHeight();
 
-    output = EncodeOutput::create(outputFileName, videoWidth, videoHeight);
+    output = EncodeOutput::create(outputFileName, videoWidth, videoHeight, codec);
     if (!output) {
         fprintf (stderr, "fail to init ouput stream\n");
         delete input;

--- a/tests/encode.cpp
+++ b/tests/encode.cpp
@@ -82,7 +82,6 @@ int main(int argc, char** argv)
     setEncoderParameters(&encVideoParams);
     encVideoParams.size = sizeof(VideoParamsCommon);
     encoder->setParameters(VideoParamsTypeCommon, &encVideoParams);
-
     // configure AVC encoding parameters
     VideoParamsAVC encVideoParamsAVC;
     encVideoParamsAVC.size = sizeof(VideoParamsAVC);
@@ -140,7 +139,10 @@ int main(int argc, char** argv)
 #endif
             if (status == ENCODE_SUCCESS
                 && output->write(outputBuffer.data, outputBuffer.dataSize)) {
-                DEBUG("timeStamp(PTS) : " "%" PRIu64 "\n", outputBuffer.timeStamp);
+                DEBUG("timeStamp(PTS) : "
+                      "%" PRIu64,
+                      outputBuffer.timeStamp);
+                DEBUG("output data size %d", outputBuffer.dataSize);
             }
 #ifdef __BUILD_GET_MV__
             if (status == ENCODE_SUCCESS) {

--- a/tests/encodehelp.h
+++ b/tests/encodehelp.h
@@ -59,8 +59,8 @@ static void print_help(const char* app)
     printf("   -o <coded file> optional\n");
     printf("   -b <bitrate: kbps> optional\n");
     printf("   -f <frame rate> optional\n");
-    printf("   -c <codec: AVC|VP8|JPEG> Note: not support now\n");
-    printf("   -s <fourcc: NV12|IYUV|YV12> Note: not support now\n");
+    printf("   -c <codec: AVC|VP8|VP9|JPEG>\n");
+    printf("   -s <fourcc: NV12|IYUV|YV12>\n");
     printf("   -N <number of frames to encode(camera default 50), useful for camera>\n");
     printf("   --qp <initial qp> optional\n");
     printf("   --rcmode <CBR|CQP> optional\n");

--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -167,43 +167,49 @@ EncodeOutput::~EncodeOutput()
         fclose(m_fp);
 }
 
-EncodeOutput* EncodeOutput::create(const char* outputFileName, int width , int height)
+EncodeOutput* EncodeOutput::create(const char* outputFileName, int width,
+                                   int height, const char* codecName)
 {
-    EncodeOutput * output = NULL;
-    if(outputFileName==NULL)
+    EncodeOutput* output = NULL;
+    if (outputFileName == NULL)
         return NULL;
-    const char *ext = strrchr(outputFileName,'.');
-    if(ext==NULL)
+    const char* ext = strrchr(outputFileName, '.');
+    std::string codec(""); // needed for strcasecmp to work
+    if (!ext && !codecName)
         return NULL;
-    ext++;//h264;264;jsv;avc;26l;jvt;ivf
-    if(strcasecmp(ext,"h264")==0 ||
-        strcasecmp(ext,"264")==0 ||
-        strcasecmp(ext,"jsv")==0 ||
-        strcasecmp(ext,"avc")==0 ||
-        strcasecmp(ext,"26l")==0 ||
-        strcasecmp(ext,"jvt")==0 ) {
-            output = new EncodeOutputH264();
+    ext++;
+
+    if (codecName)
+        codec.assign(codecName);
+
+    if (!strcasecmp("AVC", codec.c_str()) || !strcasecmp(ext, "h264")
+        || !strcasecmp(ext, "264") || !strcasecmp(ext, "jsv")
+        || !strcasecmp(ext, "avc") || !strcasecmp(ext, "26l")
+        || !strcasecmp(ext, "jvt")) {
+        output = new EncodeOutputH264();
     }
-    else if((strcasecmp(ext,"ivf")==0) ||
-            (strcasecmp(ext,"vp8")==0)) {
-            output = new EncodeOutputVP8();
+    else if (!strcasecmp("VP8", codec.c_str())
+             || (!strcasecmp("VP8", codec.c_str()) && !strcasecmp(ext, "ivf"))
+             || !strcasecmp(ext, "vp8")) {
+        output = new EncodeOutputVP8();
     }
-    else if((strcasecmp(ext,"vp9")==0)) {
-            output = new EncodeOutputVP9();
+    else if (!strcasecmp("VP9", codec.c_str())
+             || (!strcasecmp("VP9", codec.c_str()) && !strcasecmp(ext, "ivf"))
+             || !strcasecmp(ext, "vp9")) {
+        output = new EncodeOutputVP9();
     }
-    else if((strcasecmp(ext,"jpg")==0) ||
-               (strcasecmp(ext,"jpeg")==0)) {
-               output = new EncodeStreamOutputJpeg();
-   }
-    else if((strcasecmp(ext,"h265")==0) ||
-               (strcasecmp(ext,"265")==0) ||
-               (strcasecmp(ext,"hevc")==0)) {
-               output = new EncodeOutputHEVC();
+    else if (!strcasecmp("JPEG", codec.c_str()) || !strcasecmp(ext, "jpg")
+             || !strcasecmp(ext, "jpeg")) {
+        output = new EncodeStreamOutputJpeg();
+    }
+    else if (!strcasecmp("HEVC", codec.c_str()) || !strcasecmp(ext, "h265")
+             || !strcasecmp(ext, "265") || !strcasecmp(ext, "hevc")) {
+        output = new EncodeOutputHEVC();
     }
     else
         return NULL;
 
-    if(!output->init(outputFileName, width, height)) {
+    if (!output->init(outputFileName, width, height)) {
         delete output;
         return NULL;
     }

--- a/tests/encodeinput.h
+++ b/tests/encodeinput.h
@@ -147,16 +147,35 @@ class EncodeOutputH264 : public EncodeOutput
     virtual const char* getMimeType();
 };
 
-class EncodeOutputVP8 : public EncodeOutput {
+class EncodeOutputVPX : public EncodeOutput {
 public:
-    EncodeOutputVP8();
-    ~EncodeOutputVP8();
-    virtual const char* getMimeType();
+    EncodeOutputVPX();
+    ~EncodeOutputVPX();
+    virtual const char* getMimeType() = 0;
     virtual bool write(void* data, int size);
+    void setFourcc(uint32_t fourcc) {m_fourcc = fourcc;};
+    uint32_t getFourcc() {return m_fourcc;};
 protected:
     virtual bool init(const char* outputFileName, int width , int height);
 private:
+    void getIVFFileHeader(uint8_t *header, int width, int height);
     int m_frameCount;
+    uint32_t m_fourcc;
+
+};
+
+class EncodeOutputVP8 : public EncodeOutputVPX {
+public:
+    EncodeOutputVP8();
+    ~EncodeOutputVP8(){};
+    virtual const char* getMimeType();
+};
+
+class EncodeOutputVP9 : public EncodeOutputVPX {
+public:
+    EncodeOutputVP9();
+    ~EncodeOutputVP9(){};
+    virtual const char* getMimeType();
 };
 
 class EncodeStreamOutputJpeg : public EncodeOutput

--- a/tests/encodeinput.h
+++ b/tests/encodeinput.h
@@ -134,7 +134,8 @@ class EncodeOutput {
 public:
     EncodeOutput();
     virtual ~EncodeOutput();
-    static  EncodeOutput* create(const char* outputFileName, int width , int height);
+    static EncodeOutput* create(const char* outputFileName, int width,
+                                int height, const char* codecName = NULL);
     virtual bool write(void* data, int size);
     virtual const char* getMimeType() = 0;
 protected:
@@ -153,10 +154,10 @@ public:
     ~EncodeOutputVPX();
     virtual const char* getMimeType() = 0;
     virtual bool write(void* data, int size);
-    void setFourcc(uint32_t fourcc) {m_fourcc = fourcc;};
-    uint32_t getFourcc() {return m_fourcc;};
 protected:
     virtual bool init(const char* outputFileName, int width , int height);
+    uint32_t getFourcc() {return m_fourcc;};
+    void setFourcc(uint32_t fourcc) {m_fourcc = fourcc;};
 private:
     void getIVFFileHeader(uint8_t *header, int width, int height);
     int m_frameCount;
@@ -167,14 +168,12 @@ private:
 class EncodeOutputVP8 : public EncodeOutputVPX {
 public:
     EncodeOutputVP8();
-    ~EncodeOutputVP8(){};
     virtual const char* getMimeType();
 };
 
 class EncodeOutputVP9 : public EncodeOutputVPX {
 public:
     EncodeOutputVP9();
-    ~EncodeOutputVP9(){};
     virtual const char* getMimeType();
 };
 


### PR DESCRIPTION
These changes add modifications to have yamiencode handling vp9 encoding.  Since this is also modifying the vp8 path the patches are submitted for consideration.  VP9 encoder has to be enabled on libyami to operate but VP8 encoder should behave as usual. 