### PR TITLE
tests: set tempnum and priorityid for h264 encoder

### DIFF
--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -36,6 +36,8 @@ EncodeParams::EncodeParams()
     , deblockBetaOffsetDiv2(2)
     , diffQPIP(0)
     , diffQPIB(0)
+    , temporalLayerNum(1)
+    , priorityId(0)
 {
     /*nothing to do*/
 }
@@ -118,6 +120,9 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     , "0.2.1"
     , "or enableCabac, enableDct8x8 and enableDeblockFilter will use the default value");
 #endif
+    encVideoParamsAVC.temporalLayerNum = encParam->temporalLayerNum;
+    encVideoParamsAVC.priorityId = encParam->priorityId;
+
     encoder->setParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
 
     VideoConfigAVCStreamFormat streamFormat;

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -45,6 +45,8 @@ public:
     int8_t deblockBetaOffsetDiv2; //same as slice_beta_offset_div2 defined in h264 spec 7.4.3
     int8_t diffQPIP;// P frame qp minus initQP
     int8_t diffQPIB;// B frame qp minus initQP
+    uint32_t temporalLayerNum; // svc-t temporal layer number
+    uint32_t priorityId; // h264 priority_id in prefix nal unit
 };
 
 class TranscodeParams

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -43,6 +43,7 @@ static void print_help(const char* app)
     printf("   -c <codec: HEVC|AVC|VP8|JPEG>\n");
     printf("   -s <fourcc: I420|NV12|IYUV|YV12>\n");
     printf("   -N <number of frames to encode(camera default 50), useful for camera>\n");
+    printf("   -t <AVC scalability temporal layer number  (default 1)> optional\n");
     printf("   --qp <initial qp> optional\n");
     printf("   --rcmode <CBR|CQP> optional\n");
     printf("   --ipperiod <0 (I frame only) | 1 (I and P frames) | N (I,P and B frames, B frame number is N-1)> optional\n");
@@ -56,6 +57,7 @@ static void print_help(const char* app)
     printf("   --deblockbetadiv2 <AVC Beta offset of debloking filter divided 2 (default 2)> optional\n");
     printf("   --qpip <qp difference between adjacent I/P (default 0)> optional\n");
     printf("   --qpib <qp difference between adjacent I/B (default 0)> optional\n");
+    printf("   --priorityid <AVC priority_id of prefix nal unit (default 0)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -91,6 +93,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"deblockbetadiv2", required_argument, NULL, 0},
         {"qpip", required_argument, NULL, 0 },
         {"qpib", required_argument, NULL, 0 },
+        {"priorityid", required_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -99,7 +102,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         return false;
     }
 
-    while ((opt = getopt_long_only(argc, argv, "W:H:b:f:c:s:i:o:N:h:", long_opts,&option_index)) != -1)
+    while ((opt = getopt_long_only(argc, argv, "W:H:b:f:c:s:i:o:N:h:t:", long_opts,&option_index)) != -1)
     {
         switch (opt) {
         case 'h':
@@ -133,6 +136,9 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
             break;
         case 'N':
             para.frameCount = atoi(optarg);
+            break;
+        case 't':
+            para.m_encParams.temporalLayerNum = atoi(optarg);
             break;
         case 0:
              switch (option_index) {
@@ -174,6 +180,9 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                     break;
                 case 13:
                     para.m_encParams.diffQPIB = atoi(optarg);
+                    break;
+                case 14:
+                    para.m_encParams.priorityId = atoi(optarg);
                     break;
             }
         }


### PR DESCRIPTION
1. tempnum is used to specify h264 svc-t temporal layer number, default
value is 1, which means no temporal scalability needed.
2. priorityid is used to specify priority_id defined in h264 prefix nal unit, it
is needed for simulcast.

Signed-off-by: Zhong Li <zhong.li@intel.com>