### PR TITLE
do not use ::std::tr1 explicitly

### DIFF
--- a/examples/grid.cpp
+++ b/examples/grid.cpp
@@ -515,7 +515,7 @@ SharedPtr<VideoFrame> DrmRenderer::dequeue()
     SharedPtr<VideoFrame> frame;
     while (m_backs.empty())
         m_cond.wait();
-    frame = std::tr1::static_pointer_cast<VideoFrame>(m_backs.front());
+    frame = StaticPointerCast<VideoFrame>(m_backs.front());
     m_backs.pop_front();
     return frame;
 }
@@ -523,7 +523,7 @@ SharedPtr<VideoFrame> DrmRenderer::dequeue()
 bool DrmRenderer::queue(const SharedPtr<VideoFrame>& vframe)
 {
     SharedPtr<DrmFrame> frame =
-        std::tr1::static_pointer_cast<DrmFrame>(vframe);
+        StaticPointerCast<DrmFrame>(vframe);
     if (!frame) {
         ERROR("invalid frame queued");
         return false;
@@ -537,7 +537,7 @@ bool DrmRenderer::queue(const SharedPtr<VideoFrame>& vframe)
 bool DrmRenderer::discard(const SharedPtr<VideoFrame>& vframe)
 {
     SharedPtr<DrmFrame> frame =
-        std::tr1::static_pointer_cast<DrmFrame>(vframe);
+        StaticPointerCast<DrmFrame>(vframe);
     if (!frame) {
         ERROR("invalid frame queued");
         return false;

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -36,11 +36,11 @@ SharedPtr<VppInput> createInput(DecodeParameter& para, SharedPtr<NativeDisplay>&
         return input;
     }
     if(para.useCAPI){
-        SharedPtr<VppInputDecodeCapi> inputDecode = std::tr1::dynamic_pointer_cast<VppInputDecodeCapi>(input);
+        SharedPtr<VppInputDecodeCapi> inputDecode = DynamicPointerCast<VppInputDecodeCapi>(input);
         if (inputDecode && inputDecode->config(*display))
             return input;
     }else{
-        SharedPtr<VppInputDecode> inputDecode = std::tr1::dynamic_pointer_cast<VppInputDecode>(input);
+        SharedPtr<VppInputDecode> inputDecode = DynamicPointerCast<VppInputDecode>(input);
         if (inputDecode && inputDecode->config(*display))
             return input;
     }


### PR DESCRIPTION
Commit 8dc7783d1da6c reversed some of the changes in
commit 4ae3688ca7eb to use DynamicPointerCast instead
of std::tr1::dynamic_pointer_cast.  Libyami encapsulates
the use of ::std::tr1:: vs. ::std:: based on compiler.
Thus, use libyami's interface for this in decode.cpp.

Also, use libyami's SharedPointerCast in grid.cpp.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>