### PR TITLE
yamitranscode: make vp9 encoder work with yamitranscode

### DIFF
--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -161,7 +161,9 @@ VppOutput::VppOutput()
 {
 }
 
-SharedPtr<VppOutput> VppOutput::create(const char* outputFileName, uint32_t fourcc, int width, int height)
+SharedPtr<VppOutput> VppOutput::create(const char* outputFileName,
+                                       uint32_t fourcc, int width, int height,
+                                       const char* codecName)
 {
     SharedPtr<VppOutput> output;
     if (!outputFileName) {
@@ -169,12 +171,12 @@ SharedPtr<VppOutput> VppOutput::create(const char* outputFileName, uint32_t four
         return output;
     }
     output.reset(new VppOutputEncode);
-    if (output->init(outputFileName, fourcc, width, height))
+    if (output->init(outputFileName, fourcc, width, height, codecName))
         return output;
     output.reset(new VppOutputFile);
-    if (output->init(outputFileName, fourcc, width, height))
+    if (output->init(outputFileName, fourcc, width, height, codecName))
         return output;
-    ERROR("can't open %s, wroing extension?",outputFileName);
+    ERROR("can't open %s, wrong extension?",outputFileName);
     output.reset();
     return output;
 }
@@ -188,8 +190,8 @@ bool VppOutput::getFormat(uint32_t& fourcc, int& width, int& height)
     return true;
 }
 
-
-bool VppOutputFile::init(const char* outputFileName, uint32_t fourcc, int width, int height)
+bool VppOutputFile::init(const char* outputFileName, uint32_t fourcc, int width,
+                         int height, const char* /*codecName*/)
 {
     if (!outputFileName) {
         ERROR("output file name is null");

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -220,6 +220,7 @@ bool VppOutputFile::config(const SharedPtr<FrameWriter>& writer)
     return true;
 }
 
+
 VppOutputFile::~VppOutputFile()
 {
     if (m_fp)

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -274,14 +274,18 @@ protected:
 class VppOutput
 {
 public:
-    static SharedPtr<VppOutput>
-        create(const char* outputFileName, uint32_t fourcc = 0, int width = 0, int height = 0);
+    static SharedPtr<VppOutput> create(const char* outputFileName,
+                                       uint32_t fourcc = 0, int width = 0,
+                                       int height = 0,
+                                       const char* codecName = NULL);
     bool getFormat(uint32_t& fourcc, int& width, int& height);
     virtual bool output(const SharedPtr<VideoFrame>& frame) = 0;
     VppOutput();
     virtual ~VppOutput(){}
 protected:
-    virtual bool init(const char* outputFileName, uint32_t fourcc, int width, int height) = 0;
+    virtual bool init(const char* outputFileName, uint32_t fourcc, int width,
+                      int height, const char* codecName)
+        = 0;
     uint32_t m_fourcc;
     int m_width;
     int m_height;
@@ -297,7 +301,9 @@ public:
     virtual ~VppOutputFile();
     VppOutputFile();
 protected:
-    bool init(const char* outputFileName, uint32_t fourcc, int width, int height);
+    bool init(const char* outputFileName, uint32_t fourcc, int width,
+              int height, const char* codecName);
+
 private:
     bool write(const SharedPtr<VideoFrame>& frame);
     SharedPtr<FrameWriter> m_writer;

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -28,7 +28,7 @@ EncodeParams::EncodeParams()
     , intraPeriod(30)
     , numRefFrames(1)
     , idrInterval(0)
-    , codec("AVC")
+    , codec("")
     , enableCabac(true)
     , enableDct8x8(false)
     , enableDeblockFilter(true)
@@ -52,9 +52,9 @@ TranscodeParams::TranscodeParams()
     /*nothing to do*/
 }
 
-bool VppOutputEncode::init(const char* outputFileName, uint32_t /*fourcc*/, int width, int height)
+bool VppOutputEncode::init(const char* outputFileName, uint32_t /*fourcc*/,
+                           int width, int height, const char* codecName)
 {
-
     if(!width || !height)
         if (!guessResolution(outputFileName, width, height))
             return false;
@@ -62,7 +62,7 @@ bool VppOutputEncode::init(const char* outputFileName, uint32_t /*fourcc*/, int 
     m_fourcc = VA_FOURCC('N', 'V', '1', '2');
     m_width = width;
     m_height = height;
-    m_output.reset(EncodeOutput::create(outputFileName, m_width, m_height));
+    m_output.reset(EncodeOutput::create(outputFileName, m_width, m_height, codecName));
     return bool(m_output);
 }
 

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -22,7 +22,6 @@
 
 #include "vppinputoutput.h"
 using std::string;
-//#include "yamitranscodehelp.h"
 
 class EncodeParams
 {
@@ -70,7 +69,9 @@ public:
     virtual ~VppOutputEncode(){}
     bool config(NativeDisplay& nativeDisplay, const EncodeParams* encParam = NULL);
 protected:
-    virtual bool init(const char* outputFileName, uint32_t fourcc, int width, int height);
+    virtual bool init(const char* outputFileName, uint32_t fourcc, int width,
+                      int height, const char* codecName);
+
 private:
     void initOuputBuffer();
     const char* m_mime;

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -23,8 +23,12 @@
 #include "vppinputoutput.h"
 using std::string;
 
-class EncodeParams
-{
+struct EncodeParamsVP9 {
+    EncodeParamsVP9();
+    uint32_t referenceMode; // Reference mode scheme, <0 | 1>
+};
+
+class EncodeParams {
 public:
     EncodeParams();
 
@@ -46,6 +50,7 @@ public:
     int8_t diffQPIB;// B frame qp minus initQP
     uint32_t temporalLayerNum; // svc-t temporal layer number
     uint32_t priorityId; // h264 priority_id in prefix nal unit
+    EncodeParamsVP9 m_encParamsVP9;
 };
 
 class TranscodeParams

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -237,7 +237,9 @@ SharedPtr<VppInput> createInput(TranscodeParams& para, const SharedPtr<VADisplay
 
 SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADisplay>& display)
 {
-    SharedPtr<VppOutput> output = VppOutput::create(para.outputFileName.c_str(), para.fourcc, para.oWidth, para.oHeight);
+    SharedPtr<VppOutput> output = VppOutput::create(
+        para.outputFileName.c_str(), para.fourcc, para.oWidth, para.oHeight,
+        para.m_encParams.codec.c_str());
     SharedPtr<VppOutputFile> outputFile = DynamicPointerCast<VppOutputFile>(output);
     if (outputFile) {
         SharedPtr<FrameWriter> writer(new VaapiFrameWriter(display));

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -56,6 +56,10 @@ static void print_help(const char* app)
     printf("   --qpip <qp difference between adjacent I/P (default 0)> optional\n");
     printf("   --qpib <qp difference between adjacent I/B (default 0)> optional\n");
     printf("   --priorityid <AVC priority_id of prefix nal unit (default 0)> optional\n");
+    printf("   VP9 encoder specific options:\n");
+    printf("   --refmode <VP9 Reference frames mode (default 0 last(previous), "
+           "gold/alt (previous key frame) | 1 last (previous) gold (one before "
+           "last) alt (one before gold)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -92,6 +96,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"qpip", required_argument, NULL, 0 },
         {"qpib", required_argument, NULL, 0 },
         {"priorityid", required_argument, NULL, 0 },
+        {"refmode", required_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -181,6 +186,9 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                     break;
                 case 14:
                     para.m_encParams.priorityId = atoi(optarg);
+                    break;
+                case 15:
+                    para.m_encParams.m_encParamsVP9.referenceMode = atoi(optarg);
                     break;
             }
         }
@@ -326,6 +334,7 @@ public:
 #else
             dest = src;
 #endif
+
             if(!m_output->output(dest))
                 break;
             count++;
@@ -345,6 +354,7 @@ private:
         m_vpp.reset(createVideoPostProcess(YAMI_VPP_SCALER), releaseVideoPostProcess);
         return m_vpp->setNativeDisplay(nativeDisplay) == YAMI_SUCCESS;
     }
+
     SharedPtr<VADisplay> m_display;
     SharedPtr<VppInput> m_input;
     SharedPtr<VppOutput> m_output;


### PR DESCRIPTION
yamitranscode is not honoring the codec name on the command line
so it is not possible to know which codec is intended for the output
if a common extension is given. So far, common extension is ivf and it
is required that yamitranscode calls EncodeOutput->create with a codec name
for examples to run properly

supported examples below, the output file is modified on this patch. The
rest of the command line options can be modified at will

yamitranscode -i ./flambert_main.mp4_1920x1080.I420 -W 1920 -H 1080 --intraperiod 300 \
--rcmode CBR -b 2000 -o ./flambert_kfdist300_2Mbps_ytranscode.vp9

yamitranscode -i ./flambert_main.mp4_1920x1080.I420 -W 1920 -H 1080 --intraperiod 300 \
--rcmode CBR -b 2000 -o -c VP9 ./flambert_kfdist300_2Mbps_ytranscode.ivf

fixes #31 

Signed-off-by: Daniel Charles <daniel.charles@intel.com>