### PR TITLE
yamiencode: mark a force keyframe according to the intraPeriod

### DIFF
--- a/tests/encode.cpp
+++ b/tests/encode.cpp
@@ -34,6 +34,11 @@
 
 using namespace YamiMediaCodec;
 
+inline bool isVPX(const char* codec)
+{
+    return !strcmp(codec, YAMI_MIME_VP9) || !strcmp(codec, YAMI_MIME_VP8);
+}
+
 int main(int argc, char** argv)
 {
     IVideoEncoder *encoder = NULL;
@@ -131,6 +136,11 @@ int main(int argc, char** argv)
         memset(&inputBuffer, 0, sizeof(inputBuffer));
         if (input->getOneFrameInput(inputBuffer)) {
             inputBuffer.timeStamp = i++;
+
+            if (isVPX(output->getMimeType())
+                && !(encodeFrameCount % intraPeriod))
+                inputBuffer.flags |= VIDEO_FRAME_FLAGS_KEY;
+
             status = encoder->encode(&inputBuffer);
             ASSERT(status == ENCODE_SUCCESS);
             input->recycleOneFrameInput(inputBuffer);


### PR DESCRIPTION
application can request the libyami component a keyFrame on demand.
The application is requesting it based on the intraPeriod value and
libyami component will act upon.

Do this only for VPX encoding and let h.26x decide if they want to
incorporate this change later

Signed-off-by: Daniel Charles <daniel.charles@intel.com>

Fixes #33 
Requires: https://github.com/01org/libyami/pull/588