### PR TITLE
jpg_ssim: add suffix '.mjpg' into ssim_test.py

### DIFF
--- a/testscripts/ssim_test.py
+++ b/testscripts/ssim_test.py
@@ -23,6 +23,8 @@ def isCandidate(f):
         , ".mpeg"
         , ".mpg"
         , ".mpeg2"
+        , ".mjpg"
+        , ".mjpeg"
     ]
     return ext in supported
 


### PR DESCRIPTION
add jpeg suffix '.mjpg' into ssim_test.py,
so that ssim_test.py can test the conformance
of those jpeg clips.

Signed-off-by: wudping <dongpingx.wu@intel.com>