### PR TITLE
yamitransocde: implement flush for 264/265 to fix #598

### DIFF
--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -176,6 +176,8 @@ bool VppOutputEncode::output(const SharedPtr<VideoFrame>& frame)
             fprintf(stderr, "encode failed status = %d\n", status);
             return false;
         }
+    }else {
+        m_encoder->flush();
     }
     do {
         status = m_encoder->getOutput(&m_outputBuffer, drain);

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -342,7 +342,11 @@ public:
             if(count >= m_cmdParam.frameCount)
                 break;
         }
+        src.reset();
+        m_output->output(src);
+
         fps.log();
+
         return true;
     }
 private:


### PR DESCRIPTION
In the case that when we pass value 5 via --ipperiod to yamiencode, and
yamiencode conserved 2 YUV picture buffers(I B B) as B frame, the file
ends up; yamiencode does not encode until it gets a P/I frame; so those
two B frames are lost.
Added flush() function into class VppOutput, to make codec(264/265) en-
code the left B frames.

Signed-off-by: wudping <dongpingx.wu@intel.com>