### PR TITLE
v4l2enc/dec: v4l2 applications to return successfully

### DIFF
--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -1031,5 +1031,6 @@ int main(int argc, char** argv)
 #endif
 
     fprintf(stdout, "decode done\n");
+    return 0;
 }
 

--- a/tests/v4l2encode.cpp
+++ b/tests/v4l2encode.cpp
@@ -451,5 +451,6 @@ int main(int argc, char** argv)
     ASSERT(ioctlRet != -1);
 
     fprintf(stderr, "encode done\n");
+    return 0;
 }
 


### PR DESCRIPTION
v4l2encoder,v4l2decoder are required to return 0 at the end
of the main function

Signed-off-by: Daniel Charles <daniel.charles@intel.com>

Fixes #40 