### PR TITLE
tests: encode, flush frame at eos

### DIFF
--- a/tests/encode.cpp
+++ b/tests/encode.cpp
@@ -166,6 +166,7 @@ int main(int argc, char** argv)
     }
 
     // drain the output buffer
+    encoder->flush();
     do {
 #ifndef __BUILD_GET_MV__
        status = encoder->getOutput(&outputBuffer, true);


### PR DESCRIPTION
When we have b frame, encoder will cache some frame to adjust reference order.
We need flush them, else we will lost frame