### PR TITLE
md5_P010: not transform 10 bits depth YUV into I420

### DIFF
--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -413,6 +413,9 @@ bool DecodeOutputMD5::output(const SharedPtr<VideoFrame>& frame)
 {
     if (!setVideoSize(frame->crop.width, frame->crop.height))
         return false;
+    if (frame->fourcc == YAMI_FOURCC_P010)
+        m_convert.reset(new ColorConvert(m_vaDisplay, YAMI_FOURCC_P010));
+
     if (!m_convert->convert(m_data, frame))
         return false;
 


### PR DESCRIPTION
for HEVC 10 bit depth or VP9 10 bit depth, do not transform
the P010 into I420

Signed-off-by: wudping <dongpingx.wu@intel.com>