### PR TITLE
yamitranscode: add an option to support h264 simulcast

### DIFF
--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -43,6 +43,7 @@ EncodeParams::EncodeParams()
     , diffQPIB(0)
     , temporalLayerNum(1)
     , priorityId(0)
+    , enableSimucast(false)
 {
     memset(layerBitRate, 0, sizeof(layerBitRate));
 }
@@ -136,6 +137,8 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
 #endif
         encVideoParamsAVC.temporalLayerNum = encParam->temporalLayerNum;
         encVideoParamsAVC.priorityId = encParam->priorityId;
+        if (encParam->priorityId || encParam->enableSimucast)
+            encVideoParamsAVC.enablePrefixNalUnit = true;
 
         encoder->setParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
 

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -50,6 +50,9 @@ public:
     int8_t diffQPIB;// B frame qp minus initQP
     uint32_t temporalLayerNum; // svc-t temporal layer number
     uint32_t priorityId; // h264 priority_id in prefix nal unit
+    //h264 simucast means independent bitstreams with different priority.
+    //It require to set priority_id and prefix nal unit for each bitstream.
+    bool enableSimucast;
     EncodeParamsVP9 m_encParamsVP9;
     uint32_t layerBitRate[4]; // specify each scalable layer bitrate
 };

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -62,6 +62,7 @@ static void print_help(const char* app)
     printf("   --btl1 <svc-t layer 1 bitrate: kbps > optional\n");
     printf("   --btl2 <svc-t layer 2 bitrate: kbps> optional\n");
     printf("   --btl3 <svc-t layer 3 bitrate: kbps> optional\n");
+    printf("   --enable-simulcast <enable h264 simulcast, priorityid also should be set)> optional\n");
     printf("   VP9 encoder specific options:\n");
     printf("   --refmode <VP9 Reference frames mode (default 0 last(previous), "
            "gold/alt (previous key frame) | 1 last (previous) gold (one before "
@@ -109,6 +110,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"btl1", required_argument, NULL, 0 },
         {"btl2", required_argument, NULL, 0 },
         {"btl3", required_argument, NULL, 0 },
+        {"enable-simulcast", no_argument, NULL, 0},
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -219,6 +221,9 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                     break;
                 case 21:
                     para.m_encParams.layerBitRate[3] = atoi(optarg) * 1024;//kbps to bps;
+                    break;
+                case 22:
+                    para.m_encParams.enableSimucast = true;
                     break;
             }
         }


### PR DESCRIPTION
This patch is to support h264 simulcast encoding,
which means independent bitstreams with different priority.
It require to set priority_id and prefix nal unit for each bitstream.

This patch is relative to https://github.com/01org/libyami/pull/659