### PR TITLE
encode: enable lowpower mode for yamitranscode

### DIFF
--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -43,6 +43,7 @@ EncodeParams::EncodeParams()
     , diffQPIB(0)
     , temporalLayerNum(1)
     , priorityId(0)
+    , enableLowPower(false)
 {
     memset(layerBitRate, 0, sizeof(layerBitRate));
 }
@@ -108,6 +109,7 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encVideoParams.rcParams.diffQPIB = encParam->diffQPIB;
     encVideoParams.rcMode = encParam->rcMode;
     encVideoParams.numRefFrames = encParam->numRefFrames;
+    encVideoParams.enableLowPower = encParam->enableLowPower;
     memcpy(encVideoParams.rcParams.layerBitRate, encParam->layerBitRate,
            sizeof(encParam->layerBitRate));
     encVideoParams.size = sizeof(VideoParamsCommon);

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -52,6 +52,7 @@ public:
     uint32_t priorityId; // h264 priority_id in prefix nal unit
     EncodeParamsVP9 m_encParamsVP9;
     uint32_t layerBitRate[4]; // specify each scalable layer bitrate
+    bool enableLowPower;
 };
 
 class TranscodeParams

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -62,6 +62,7 @@ static void print_help(const char* app)
     printf("   --btl1 <svc-t layer 1 bitrate: kbps > optional\n");
     printf("   --btl2 <svc-t layer 2 bitrate: kbps> optional\n");
     printf("   --btl3 <svc-t layer 3 bitrate: kbps> optional\n");
+    printf("   --lowpower <Enable AVC low power mode (default 0, Disabled)> optional\n");
     printf("   VP9 encoder specific options:\n");
     printf("   --refmode <VP9 Reference frames mode (default 0 last(previous), "
            "gold/alt (previous key frame) | 1 last (previous) gold (one before "
@@ -109,6 +110,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"btl1", required_argument, NULL, 0 },
         {"btl2", required_argument, NULL, 0 },
         {"btl3", required_argument, NULL, 0 },
+        {"lowpower", no_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -219,6 +221,9 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                     break;
                 case 21:
                     para.m_encParams.layerBitRate[3] = atoi(optarg) * 1024;//kbps to bps;
+                    break;
+                case 22:
+                    para.m_encParams.enableLowPower = true;
                     break;
             }
         }


### PR DESCRIPTION
add lowpower option to yamitranscode.
Signed-off-by: jkyu <jiankang.yu@intel.com>