### PR TITLE
common: deal with return value of guessFourcc

### DIFF
--- a/tests/decodehelp.cpp
+++ b/tests/decodehelp.cpp
@@ -133,8 +133,11 @@ bool processCmdLine(int argc, char** argv, DecodeParameter* parameters)
     if (outputFile.empty())
         outputFile = "./";
     parameters->outputFile = outputFile;
-    if (!isSetFourcc)
+    if (!isSetFourcc) {
         parameters->renderFourcc = guessFourcc(parameters->outputFile.c_str());
+        if (!parameters->renderFourcc)
+            parameters->renderFourcc = YAMI_FOURCC_I420;
+    }
     int width, height;
     if (guessResolution(parameters->inputFile, width, height)) {
         parameters->width = width;

--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -94,8 +94,11 @@ bool EncodeInputFile::init(const char* inputFileName, uint32_t fourcc, int width
         return false;
     }
 
-    if (!m_fourcc)
+    if (!m_fourcc) {
         m_fourcc = guessFourcc(inputFileName);
+        if (!m_fourcc)
+            m_fourcc = YAMI_FOURCC_I420;
+    }
 
     if (!m_fourcc)
         m_fourcc = VA_FOURCC('I', '4', '2', '0');

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -104,11 +104,12 @@ static bool guessFormat(const char* filename, uint32_t& fourcc, int& width, int&
             return false;
         }
     }
-    if (!fourcc)
+    if (!fourcc) {
         fourcc = guessFourcc(filename);
+        if (!fourcc)
+            fourcc = YAMI_FOURCC_I420;
+    }
 
-    if (!fourcc)
-        fourcc = VA_FOURCC('I', '4', '2', '0');
     return true;
 }
 


### PR DESCRIPTION
Because the return value of guessFourcc() is 0, here need to set default fourcc
when guessFourcc() returns 0.

Signed-off-by: wudping <dongpingx.wu@intel.com>