### PR TITLE
hevc10bit: implement hevc 10 bit-depth transcoding

### DIFF
--- a/tests/vppinputasync.cpp
+++ b/tests/vppinputasync.cpp
@@ -72,6 +72,9 @@ void VppInputAsync::loop()
 bool VppInputAsync::init(const SharedPtr<VppInput>& input, uint32_t queueSize)
 {
     m_input = input;
+    m_fourcc = input->getFourcc();
+    m_width = input->getWidth();
+    m_height = input->getHeight();
     m_queueSize = queueSize;
     if (pthread_create(&m_thread, NULL, start, this)) {
         ERROR("create thread failed");

--- a/tests/vppinputdecode.cpp
+++ b/tests/vppinputdecode.cpp
@@ -75,6 +75,7 @@ bool VppInputDecode::read(SharedPtr<VideoFrame>& frame)
                 const VideoFormatInfo* info = m_decoder->getFormatInfo();
                 m_width = info->width;
                 m_height = info->height;
+                m_fourcc = info->fourcc;
 
                 //resend the buffer
                 status = m_decoder->decode(&inputBuffer);

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -175,6 +175,7 @@ public:
     virtual bool read(SharedPtr<VideoFrame>& frame) = 0;
     int getWidth() { return m_width;}
     int getHeight() { return m_height;}
+    uint32_t getFourcc() { return m_fourcc; }
 
     virtual ~VppInput() {}
 protected:

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -44,6 +44,7 @@ EncodeParams::EncodeParams()
     , temporalLayerNum(1)
     , priorityId(0)
     , enableLowPower(false)
+    , bitDepth(8)
 {
     memset(layerBitRate, 0, sizeof(layerBitRate));
 }
@@ -55,19 +56,20 @@ TranscodeParams::TranscodeParams()
     , iHeight(0)
     , oWidth(0)
     , oHeight(0)
-    , fourcc(VA_FOURCC_NV12)
+    , fourcc(0)
 {
     /*nothing to do*/
 }
 
-bool VppOutputEncode::init(const char* outputFileName, uint32_t /*fourcc*/,
-                           int width, int height, const char* codecName)
+bool VppOutputEncode::init(const char* outputFileName, uint32_t fourcc,
+    int width, int height, const char* codecName)
 {
     if(!width || !height)
         if (!guessResolution(outputFileName, width, height))
             return false;
-
-    m_fourcc = VA_FOURCC('N', 'V', '1', '2');
+    if (YAMI_FOURCC_P010 != fourcc)
+        fourcc = YAMI_FOURCC_NV12;
+    m_fourcc = fourcc;
     m_width = width;
     m_height = height;
     m_output.reset(EncodeOutput::create(outputFileName, m_width, m_height, codecName));
@@ -110,6 +112,7 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encVideoParams.rcMode = encParam->rcMode;
     encVideoParams.numRefFrames = encParam->numRefFrames;
     encVideoParams.enableLowPower = encParam->enableLowPower;
+    encVideoParams.bitDepth = encParam->bitDepth;
     memcpy(encVideoParams.rcParams.layerBitRate, encParam->layerBitRate,
            sizeof(encParam->layerBitRate));
     encVideoParams.size = sizeof(VideoParamsCommon);

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -53,6 +53,7 @@ public:
     EncodeParamsVP9 m_encParamsVP9;
     uint32_t layerBitRate[4]; // specify each scalable layer bitrate
     bool enableLowPower;
+    uint8_t bitDepth;
 };
 
 class TranscodeParams

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -263,7 +263,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
 
 SharedPtr<VppInput> createInput(TranscodeParams& para, const SharedPtr<VADisplay>& display)
 {
-    SharedPtr<VppInput> input(VppInput::create(para.inputFileName.c_str(), 0, para.iWidth, para.iHeight));
+    SharedPtr<VppInput> input(VppInput::create(para.inputFileName.c_str(), para.fourcc, para.iWidth, para.iHeight));
     if (!input) {
         ERROR("creat input failed");
         return input;
@@ -292,10 +292,10 @@ SharedPtr<VppInput> createInput(TranscodeParams& para, const SharedPtr<VADisplay
     return input;
 }
 
-SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADisplay>& display)
+SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADisplay>& display, uint32_t fourcc)
 {
     SharedPtr<VppOutput> output = VppOutput::create(
-        para.outputFileName.c_str(), para.fourcc, para.oWidth, para.oHeight,
+        para.outputFileName.c_str(), fourcc, para.oWidth, para.oHeight,
         para.m_encParams.codec.c_str());
     SharedPtr<VppOutputFile> outputFile = DynamicPointerCast<VppOutputFile>(output);
     if (outputFile) {
@@ -351,7 +351,11 @@ public:
             return false;
         }
         m_input = createInput(m_cmdParam, m_display);
-        m_output =  createOutput(m_cmdParam, m_display);
+
+        if (m_input->getFourcc() == YAMI_FOURCC_P010)
+            m_cmdParam.m_encParams.bitDepth = 10;
+
+        m_output = createOutput(m_cmdParam, m_display, m_input->getFourcc());
         if (!m_input || !m_output) {
             ERROR("create input or output failed");
             return false;


### PR DESCRIPTION
Because add a new bit-depth transcoding, the original logical
to set fourcc becomes more complex. The principle of transcoding
this patch follows as below:
1, the commandline parameter '-s' is just used to set input yuv
   file's fourcc. Only yuv file, it not for other file such as
   H264, VP8 and so on. the file in 264 or other format, their
   fourcc is depended on the first decoded frame.
2, for the output file's fourcc, it firstly comes from the extra
   file name. For example, output file "dd_1920x1080.I420", its
   fourcc is I420. For other can't guess fourcc by its extra name,
   use the fourcc from Vppinput object. For example, output file
   "dd_1920x1080.yuv", that can't guess the fourcc, it will use the
   input file's fourcc. Or output file "dd_1920x1080.265", it also
   uses the input file's fourcc.

Signed-off-by: wudping <dongpingx.wu@intel.com>