### PR TITLE
add --startup-size option to yamitranscode and yamvpp 

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -120,7 +120,7 @@ v4l2encode_SOURCES = v4l2encode.cpp encodeinput.h encodeinput.cpp encodeInputCam
 
 yamivpp_LDADD    = $(YAMI_VPP_LIBS)
 yamivpp_LDFLAGS  = $(YAMI_VPP_LDFLAGS)
-yamivpp_SOURCES  = vppinputdecode.cpp vppinputoutput.cpp vppoutputencode.cpp  vpp.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES) vppinputdecodecapi.cpp
+yamivpp_SOURCES  = vppinputdecode.cpp vppinputoutput.cpp vppoutputencode.cpp  vpp.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES) vppinputasync.cpp vppinputdecodecapi.cpp
 
 yamitranscode_LDADD    = $(YAMI_VPP_LIBS)
 yamitranscode_LDFLAGS  = -pthread $(YAMI_VPP_LDFLAGS)

--- a/tests/vpp.cpp
+++ b/tests/vpp.cpp
@@ -21,6 +21,7 @@
 #include "vppoutputencode.h"
 #include "encodeinput.h"
 #include "common/log.h"
+#include "tests/vppinputasync.h"
 #include <Yami.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,8 +32,10 @@ using namespace YamiMediaCodec;
 
 void usage();
 
-SharedPtr<VppInput> createInput(const char* filename, const SharedPtr<VADisplay>& display)
+SharedPtr<VppInput> createInput(const char* filename, const SharedPtr<VADisplay>& display, uint32_t startupSize)
 {
+    const uint32_t kQueueSize = 5;
+    const uint32_t kExtraSize = 3;
     SharedPtr<VppInput> input(VppInput::create(filename));
     if (!input) {
         ERROR("creat input failed");
@@ -41,10 +44,13 @@ SharedPtr<VppInput> createInput(const char* filename, const SharedPtr<VADisplay>
     SharedPtr<VppInputFile> inputFile = DynamicPointerCast<VppInputFile>(input);
     if (inputFile) {
         SharedPtr<FrameReader> reader(new VaapiFrameReader(display));
-        SharedPtr<FrameAllocator> alloctor(new PooledFrameAllocator(display, 5));
+        SharedPtr<FrameAllocator> alloctor(new PooledFrameAllocator(display, kQueueSize + kExtraSize + startupSize));
         inputFile->config(alloctor, reader);
     }
-    return inputFile;
+    if (input) {
+        input = VppInputAsync::create(input, kQueueSize, startupSize); //make input in other thread.
+    }
+    return input;
 }
 
 SharedPtr<VppOutput> createOutput(const char* filename, const SharedPtr<VADisplay>& display)
@@ -100,6 +106,8 @@ public:
         , m_brightness(COLORBALANCE_LEVEL_NONE)
         , m_contrast(COLORBALANCE_LEVEL_NONE)
 #endif
+        , m_count(-1)
+        , m_startupSize(0)
     {
     }
     bool init(int argc, char** argv)
@@ -115,7 +123,7 @@ public:
             ERROR("create vpp failed");
             return false;
         }
-        m_input = createInput(m_inputName, m_display);
+        m_input = createInput(m_inputName, m_display, m_startupSize);
         m_output = createOutput(m_outputName, m_display);
         if (!m_input || !m_output) {
             printf("create input or output failed");
@@ -130,7 +138,7 @@ public:
 
         SharedPtr<VideoFrame> src, dest;
         YamiStatus  status;
-        int count = 0;
+        uint32_t count = 0;
         while (m_input->read(src)) {
             dest = m_allocator->alloc();
             status = m_vpp->process(src, dest);
@@ -140,6 +148,8 @@ public:
             }
             m_output->output(dest);
             count++;
+            if (count >= m_count)
+                break;
         }
         //flush output
         dest.reset();
@@ -161,6 +171,8 @@ private:
             { "sat", required_argument, NULL, 0 },
             { "br", required_argument, NULL, 0 },
             { "con", required_argument, NULL, 0 },
+            { "startup-size", required_argument, NULL, 0 },
+            { "count", required_argument, NULL, 'n' },
             { NULL, no_argument, NULL, 0 }
         };
         int option_index;
@@ -170,7 +182,7 @@ private:
             return false;
         }
 
-        while ((opt = getopt_long_only(argc, argv, "s:h:", long_opts, &option_index)) != -1) {
+        while ((opt = getopt_long_only(argc, argv, "s:h:n:", long_opts, &option_index)) != -1) {
             switch (opt) {
             case 'h':
             case '?':
@@ -178,6 +190,9 @@ private:
                 return false;
             case 's':
                 m_sharpening = atoi(optarg);
+                break;
+            case 'n':
+                m_count = atoi(optarg);
                 break;
             case 0:
                 switch (option_index) {
@@ -198,6 +213,9 @@ private:
                     break;
                 case 7:
                     m_contrast = atoi(optarg);
+                    break;
+                case 8:
+                    m_startupSize = atoi(optarg);
                     break;
                 default:
                     usage();
@@ -313,6 +331,8 @@ private:
     int32_t m_saturation;
     int32_t m_brightness;
     int32_t m_contrast;
+    uint32_t m_count;
+    uint32_t m_startupSize;
 };
 
 void usage()
@@ -328,6 +348,8 @@ void usage()
     printf("       --sat <level>, optional, saturation level, range [0, 100] or -1, -1: delete this filter\n");
     printf("       --br <level>, optional, brightness level, range [0, 100] or -1, -1: delete this filter\n");
     printf("       --con <level>, optional, constrast level, range [0, 100] or -1, -1: delete this filter\n");
+    printf("       --startup-size <size>, optional, preload yuv size\n");
+    printf("       -n <count>, optional, stop at <count> frames\n");
 }
 
 int main(int argc, char** argv)

--- a/tests/vppinputasync.cpp
+++ b/tests/vppinputasync.cpp
@@ -15,22 +15,27 @@
  */
 #include "vppinputasync.h"
 
+static const pthread_t INVALID_THREAD_ID = ((pthread_t)-1);
+
 VppInputAsync::VppInputAsync()
-    :m_cond(m_lock), m_eos(false),
-     m_queueSize(0),m_quit(false)
+    : m_cond(m_lock)
+    , m_eos(false)
+    , m_queueSize(0)
+    , m_startupSize(0)
+    , m_thread(INVALID_THREAD_ID)
+    , m_quit(false)
 {
 }
 
-
 SharedPtr<VppInput>
-VppInputAsync::create(const SharedPtr<VppInput>& input, uint32_t queueSize)
+VppInputAsync::create(const SharedPtr<VppInput>& input, uint32_t queueSize, uint32_t startupSize)
 {
     SharedPtr<VppInput> ret;
 
     if (!input || !queueSize)
         return ret;
     SharedPtr<VppInputAsync> async(new VppInputAsync());
-    if (!async->init(input, queueSize)) {
+    if (!async->init(input, queueSize, startupSize)) {
         ERROR("init VppInputAsync failed");
         return ret;
     }
@@ -69,18 +74,48 @@ void VppInputAsync::loop()
    }
 }
 
-bool VppInputAsync::init(const SharedPtr<VppInput>& input, uint32_t queueSize)
+bool VppInputAsync::preloadFrames(uint32_t startupSize)
 {
-    m_input = input;
-    m_queueSize = queueSize;
-    if (pthread_create(&m_thread, NULL, start, this)) {
-        ERROR("create thread failed");
-        return false;
+    uint32_t size;
+    for (size = 0; size < startupSize; size++) {
+        SharedPtr<VideoFrame> frame;
+        if (!m_input->read(frame))
+            break;
+        m_queue.push_back(frame);
+    }
+    if (!size) {
+        ERROR("can't read file from input");
+    }
+    //if the input file do not have enough frames
+    //we will duplicate frames.
+    if (startupSize > size) {
+        uint32_t left = startupSize - size;
+        for (uint32_t i = 0; i < left; i++) {
+            //loop entire queue;
+            uint32_t idx = i % size;
+            m_queue.push_back(m_queue[idx]);
+        }
     }
     return true;
 
 }
 
+bool VppInputAsync::init(const SharedPtr<VppInput>& input, uint32_t queueSize, uint32_t startupSize)
+{
+    m_input = input;
+    m_queueSize = queueSize;
+    m_startupSize = startupSize;
+    if (startupSize) {
+        return preloadFrames(startupSize);
+    }
+    else {
+        if (pthread_create(&m_thread, NULL, start, this)) {
+            ERROR("create thread failed");
+            return false;
+        }
+    }
+    return true;
+}
 bool VppInputAsync::read(SharedPtr<VideoFrame>& frame)
 {
     AutoLock lock(m_lock);
@@ -91,18 +126,24 @@ bool VppInputAsync::read(SharedPtr<VideoFrame>& frame)
     }
     frame = m_queue.front();
     m_queue.pop_front();
+    if (m_startupSize) {
+        //we make a buffer loop here.
+        m_queue.push_back(frame);
+    }
     m_cond.signal();
     return true;
 }
 
 VppInputAsync::~VppInputAsync()
 {
-    {
-        AutoLock lock(m_lock);
-        m_quit = true;
-        m_cond.signal();
+    if (m_thread != INVALID_THREAD_ID) {
+        {
+            AutoLock lock(m_lock);
+            m_quit = true;
+            m_cond.signal();
+        }
+        pthread_join(m_thread, NULL);
     }
-    pthread_join(m_thread, NULL);
 }
 
 bool VppInputAsync::init(const char* inputFileName, uint32_t fourcc, int width, int height)

--- a/tests/vppinputasync.h
+++ b/tests/vppinputasync.h
@@ -28,8 +28,9 @@ public:
 
     bool read(SharedPtr<VideoFrame>& frame);
 
+    /*startupSize means how many buffers will preload to memory in startup, it will overide queueSize*/
     static SharedPtr<VppInput>
-    create(const SharedPtr<VppInput>& input, uint32_t queueSize);
+    create(const SharedPtr<VppInput>& input, uint32_t queueSize, uint32_t startupSize = 0);
 
     VppInputAsync();
     virtual ~VppInputAsync();
@@ -37,9 +38,10 @@ public:
     //do not use this
     bool init(const char* inputFileName, uint32_t fourcc, int width, int height);
 private:
-    bool init(const SharedPtr<VppInput>& input, uint32_t queueSize);
+    bool init(const SharedPtr<VppInput>& input, uint32_t queueSize, uint32_t startupSize);
     static void* start(void* async);
     void loop();
+    bool preloadFrames(uint32_t startupSize);
 
     Condition  m_cond;
     Lock       m_lock;
@@ -49,6 +51,7 @@ private:
     typedef std::deque<SharedPtr<VideoFrame> > FrameQueue;
     FrameQueue m_queue;
     uint32_t   m_queueSize;
+    uint32_t m_startupSize;
 
     pthread_t  m_thread;
     bool       m_quit;

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -56,6 +56,7 @@ TranscodeParams::TranscodeParams()
     , oWidth(0)
     , oHeight(0)
     , fourcc(VA_FOURCC_NV12)
+    , startupSize(0)
 {
     /*nothing to do*/
 }

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -69,6 +69,7 @@ public:
     uint32_t fourcc;
     string inputFileName;
     string outputFileName;
+    uint32_t startupSize;
 };
 
 class VppOutputEncode : public VppOutput


### PR DESCRIPTION
This option will preload yuv to memory. It will help to measure encode and vpp performance.
Example:
`yamivpp -n 1000 --startup-size 100  1920x1080.nv12 320x240.i420 --skip-dump`
It will preload 100 frames to memory, then loop the 100 frame and stop after 1000 frames processed.
