### PR TITLE
Yamitrans hevc10bit

### DIFF
--- a/tests/vppinputasync.h
+++ b/tests/vppinputasync.h
@@ -33,6 +33,9 @@ public:
 
     VppInputAsync();
     virtual ~VppInputAsync();
+    virtual int getWidth() { return m_input->getWidth(); }
+    virtual int getHeight() { return m_input->getHeight(); }
+    virtual uint32_t getFourcc() { return m_input->getFourcc(); }
 
     //do not use this
     bool init(const char* inputFileName, uint32_t fourcc, int width, int height);

--- a/tests/vppinputdecode.cpp
+++ b/tests/vppinputdecode.cpp
@@ -75,6 +75,7 @@ bool VppInputDecode::read(SharedPtr<VideoFrame>& frame)
                 const VideoFormatInfo* info = m_decoder->getFormatInfo();
                 m_width = info->width;
                 m_height = info->height;
+                m_fourcc = info->fourcc;
 
                 //resend the buffer
                 status = m_decoder->decode(&inputBuffer);

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -107,8 +107,6 @@ static bool guessFormat(const char* filename, uint32_t& fourcc, int& width, int&
     if (!fourcc)
         fourcc = guessFourcc(filename);
 
-    if (!fourcc)
-        fourcc = VA_FOURCC('I', '4', '2', '0');
     return true;
 }
 

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -173,8 +173,9 @@ public:
         create(const char* inputFileName, uint32_t fourcc = 0, int width = 0, int height = 0, bool useCAPI = false);
     virtual bool init(const char* inputFileName = 0, uint32_t fourcc = 0, int width = 0, int height = 0) = 0;
     virtual bool read(SharedPtr<VideoFrame>& frame) = 0;
-    int getWidth() { return m_width;}
-    int getHeight() { return m_height;}
+    virtual int getWidth() { return m_width; }
+    virtual int getHeight() { return m_height; }
+    virtual uint32_t getFourcc() { return m_fourcc; }
 
     virtual ~VppInput() {}
 protected:

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -263,7 +263,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
 
 SharedPtr<VppInput> createInput(TranscodeParams& para, const SharedPtr<VADisplay>& display)
 {
-    SharedPtr<VppInput> input(VppInput::create(para.inputFileName.c_str(), 0, para.iWidth, para.iHeight));
+    SharedPtr<VppInput> input(VppInput::create(para.inputFileName.c_str(), para.fourcc, para.iWidth, para.iHeight));
     if (!input) {
         ERROR("creat input failed");
         return input;
@@ -292,10 +292,10 @@ SharedPtr<VppInput> createInput(TranscodeParams& para, const SharedPtr<VADisplay
     return input;
 }
 
-SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADisplay>& display)
+SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADisplay>& display, uint32_t fourcc)
 {
     SharedPtr<VppOutput> output = VppOutput::create(
-        para.outputFileName.c_str(), para.fourcc, para.oWidth, para.oHeight,
+        para.outputFileName.c_str(), fourcc, para.oWidth, para.oHeight,
         para.m_encParams.codec.c_str());
     SharedPtr<VppOutputFile> outputFile = DynamicPointerCast<VppOutputFile>(output);
     if (outputFile) {
@@ -351,7 +351,7 @@ public:
             return false;
         }
         m_input = createInput(m_cmdParam, m_display);
-        m_output =  createOutput(m_cmdParam, m_display);
+        m_output = createOutput(m_cmdParam, m_display, m_input->getFourcc());
         if (!m_input || !m_output) {
             ERROR("create input or output failed");
             return false;


### PR DESCRIPTION
Implement 10 bits-depth transcoding.
Command line parameter "-s" is just used to set input file's fourcc in case fourcc of input file can not be guessed via its extra name.