### PR TITLE
encoder: add fps for VP8/VP9

### DIFF
--- a/tests/encode.cpp
+++ b/tests/encode.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
     if (YAMI_FOURCC_P010 == input->getFourcc())
         bitDepth = 10;
 
-    output = EncodeOutput::create(outputFileName, videoWidth, videoHeight, codec);
+    output = EncodeOutput::create(outputFileName, videoWidth, videoHeight, fps, codec);
     if (!output) {
         fprintf (stderr, "fail to init output stream\n");
         delete input;

--- a/tests/encodeInputCapi.cpp
+++ b/tests/encodeInputCapi.cpp
@@ -29,9 +29,9 @@ EncodeInputHandler createEncodeInput(const char * inputFileName, uint32_t fourcc
     return EncodeInput::create(inputFileName, fourcc, width, height);
 }
 
-EncodeOutputHandler createEncodeOutput(const char * outputFileName, int width, int height)
+EncodeOutputHandler createEncodeOutput(const char* outputFileName, int width, int height, int fps)
 {
-    return EncodeOutput::create(outputFileName, width, height);
+    return EncodeOutput::create(outputFileName, width, height, fps);
 }
 
 bool encodeInputIsEOS(EncodeInputHandler input)

--- a/tests/encodeInputCapi.h
+++ b/tests/encodeInputCapi.h
@@ -28,7 +28,7 @@ typedef void* EncodeOutputHandler;
 
 EncodeInputHandler createEncodeInput(const char * inputFileName, uint32_t fourcc, int width, int height);
 
-EncodeOutputHandler createEncodeOutput(const char * outputFileName, int width, int height);
+EncodeOutputHandler createEncodeOutput(const char* outputFileName, int width, int height, int fps = 30);
 
 bool encodeInputIsEOS(EncodeInputHandler input);
 

--- a/tests/encodecapi.c
+++ b/tests/encodecapi.c
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
     videoWidth = getInputWidth(input);
     videoHeight = getInputHeight(input);
 
-    output = createEncodeOutput(outputFileName, videoWidth, videoHeight);
+    output = createEncodeOutput(outputFileName, videoWidth, videoHeight, fps);
     if(!output) {
       fprintf(stderr, "fail to init ourput stream\n");
       return -1;

--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -171,7 +171,7 @@ EncodeOutput::~EncodeOutput()
 }
 
 EncodeOutput* EncodeOutput::create(const char* outputFileName, int width,
-                                   int height, const char* codecName)
+    int height, int fps, const char* codecName)
 {
     EncodeOutput* output = NULL;
     if (outputFileName == NULL)
@@ -212,14 +212,14 @@ EncodeOutput* EncodeOutput::create(const char* outputFileName, int width,
     else
         return NULL;
 
-    if (!output->init(outputFileName, width, height)) {
+    if (!output->init(outputFileName, width, height, fps)) {
         delete output;
         return NULL;
     }
     return output;
 }
 
-bool EncodeOutput::init(const char* outputFileName, int width , int height)
+bool EncodeOutput::init(const char* outputFileName, int width, int height, int fps)
 {
     m_fp = fopen(outputFileName, "w+");
     if (!m_fp) {
@@ -271,7 +271,7 @@ void setUint16(uint8_t* header, uint16_t value)
     *h = value;
 }
 
-void EncodeOutputVPX::getIVFFileHeader(uint8_t *header, int width, int height)
+void EncodeOutputVPX::getIVFFileHeader(uint8_t* header, int width, int height, int fps)
 {
     setUint32(header, YAMI_FOURCC('D','K','I','F'));
     setUint16(header+4, 0);                     // version
@@ -279,18 +279,18 @@ void EncodeOutputVPX::getIVFFileHeader(uint8_t *header, int width, int height)
     setUint32(header+8,  m_fourcc);             // fourcc
     setUint16(header+12, width);                // width
     setUint16(header+14, height);               // height
-    setUint32(header+16, 30);                   // rate
+    setUint32(header + 16, fps); // rate
     setUint32(header+20, 1);                    // scale
     setUint32(header+24, m_frameCount);         // framecount
     setUint32(header+28, 0);                    // unused
 }
 
-bool EncodeOutputVPX::init(const char* outputFileName, int width , int height)
+bool EncodeOutputVPX::init(const char* outputFileName, int width, int height, int fps)
 {
     if (!EncodeOutput::init(outputFileName, width, height))
         return false;
     uint8_t header[32];
-    getIVFFileHeader(header, width, height);
+    getIVFFileHeader(header, width, height, fps);
     return EncodeOutput::write(header, sizeof(header));
 }
 

--- a/tests/encodeinput.h
+++ b/tests/encodeinput.h
@@ -135,11 +135,11 @@ public:
     EncodeOutput();
     virtual ~EncodeOutput();
     static EncodeOutput* create(const char* outputFileName, int width,
-                                int height, const char* codecName = NULL);
+        int height, int fps = 30, const char* codecName = NULL);
     virtual bool write(void* data, int size);
     virtual const char* getMimeType() = 0;
 protected:
-    virtual bool init(const char* outputFileName, int width , int height);
+    virtual bool init(const char* outputFileName, int width, int height, int fps = 30);
     FILE *m_fp;
 };
 
@@ -155,11 +155,11 @@ public:
     virtual const char* getMimeType() = 0;
     virtual bool write(void* data, int size);
 protected:
-    virtual bool init(const char* outputFileName, int width , int height);
+    virtual bool init(const char* outputFileName, int width, int height, int fps = 30);
     uint32_t getFourcc() {return m_fourcc;};
     void setFourcc(uint32_t fourcc) {m_fourcc = fourcc;};
 private:
-    void getIVFFileHeader(uint8_t *header, int width, int height);
+    void getIVFFileHeader(uint8_t* header, int width, int height, int fps = 30);
     int m_frameCount;
     uint32_t m_fourcc;
 

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -160,8 +160,8 @@ VppOutput::VppOutput()
 }
 
 SharedPtr<VppOutput> VppOutput::create(const char* outputFileName,
-                                       uint32_t fourcc, int width, int height,
-                                       const char* codecName)
+    uint32_t fourcc, int width, int height,
+    const char* codecName, int fps)
 {
     SharedPtr<VppOutput> output;
     if (!outputFileName) {
@@ -169,7 +169,7 @@ SharedPtr<VppOutput> VppOutput::create(const char* outputFileName,
         return output;
     }
     output.reset(new VppOutputEncode);
-    if (output->init(outputFileName, fourcc, width, height, codecName))
+    if (output->init(outputFileName, fourcc, width, height, codecName, fps))
         return output;
     output.reset(new VppOutputFile);
     if (output->init(outputFileName, fourcc, width, height, codecName))
@@ -189,7 +189,7 @@ bool VppOutput::getFormat(uint32_t& fourcc, int& width, int& height)
 }
 
 bool VppOutputFile::init(const char* outputFileName, uint32_t fourcc, int width,
-                         int height, const char* /*codecName*/)
+    int height, const char* /*codecName*/, int fps)
 {
     if (!outputFileName) {
         ERROR("output file name is null");

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -204,16 +204,17 @@ class VppOutput
 {
 public:
     static SharedPtr<VppOutput> create(const char* outputFileName,
-                                       uint32_t fourcc = 0, int width = 0,
-                                       int height = 0,
-                                       const char* codecName = NULL);
+        uint32_t fourcc = 0, int width = 0,
+        int height = 0,
+        const char* codecName = NULL,
+        int fps = 30);
     bool getFormat(uint32_t& fourcc, int& width, int& height);
     virtual bool output(const SharedPtr<VideoFrame>& frame) = 0;
     VppOutput();
     virtual ~VppOutput(){}
 protected:
     virtual bool init(const char* outputFileName, uint32_t fourcc, int width,
-                      int height, const char* codecName)
+        int height, const char* codecName, int fps = 30)
         = 0;
     uint32_t m_fourcc;
     int m_width;
@@ -230,8 +231,8 @@ public:
     virtual ~VppOutputFile();
     VppOutputFile();
 protected:
-    bool init(const char* outputFileName, uint32_t fourcc, int width,
-              int height, const char* codecName);
+    virtual bool init(const char* outputFileName, uint32_t fourcc, int width,
+        int height, const char* codecName, int fps = 30);
 
 private:
     bool write(const SharedPtr<VideoFrame>& frame);

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -61,7 +61,7 @@ TranscodeParams::TranscodeParams()
 }
 
 bool VppOutputEncode::init(const char* outputFileName, uint32_t fourcc,
-    int width, int height, const char* codecName)
+    int width, int height, const char* codecName, int fps)
 {
     if(!width || !height)
         if (!guessResolution(outputFileName, width, height))
@@ -69,7 +69,7 @@ bool VppOutputEncode::init(const char* outputFileName, uint32_t fourcc,
     m_fourcc = fourcc != YAMI_FOURCC_P010 ? YAMI_FOURCC_NV12 : YAMI_FOURCC_P010;
     m_width = width;
     m_height = height;
-    m_output.reset(EncodeOutput::create(outputFileName, m_width, m_height, codecName));
+    m_output.reset(EncodeOutput::create(outputFileName, m_width, m_height, fps, codecName));
     return bool(m_output);
 }
 

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -79,7 +79,7 @@ public:
     bool config(NativeDisplay& nativeDisplay, const EncodeParams* encParam = NULL);
 protected:
     virtual bool init(const char* outputFileName, uint32_t fourcc, int width,
-                      int height, const char* codecName);
+        int height, const char* codecName, int fps = 30);
 
 private:
     void initOuputBuffer();

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -296,7 +296,7 @@ SharedPtr<VppOutput> createOutput(TranscodeParams& para, const SharedPtr<VADispl
 {
     SharedPtr<VppOutput> output = VppOutput::create(
         para.outputFileName.c_str(), fourcc, para.oWidth, para.oHeight,
-        para.m_encParams.codec.c_str());
+        para.m_encParams.codec.c_str(), para.m_encParams.fps);
     SharedPtr<VppOutputFile> outputFile = DynamicPointerCast<VppOutputFile>(output);
     if (outputFile) {
         SharedPtr<FrameWriter> writer(new VaapiFrameWriter(display));


### PR DESCRIPTION
Just adding fps for VP8/VP9

to fix issue [#696](https://github.com/01org/libyami/issues/696)

Signed-off-by: wudping <dongpingx.wu@intel.com>