### PR TITLE
enc: resize output buffer size

### DIFF
--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -331,11 +331,15 @@ EncodeOutputVP9::EncodeOutputVP9()
 
 bool createOutputBuffer(VideoEncOutputBuffer* outputBuffer, int maxOutSize)
 {
-    outputBuffer->data = static_cast<uint8_t*>(malloc(maxOutSize));
-    if (!outputBuffer->data)
+    uint8_t* tmp;
+    tmp = static_cast<uint8_t*>(malloc(maxOutSize));
+    if (!tmp)
         return false;
     outputBuffer->bufferSize = maxOutSize;
     outputBuffer->format = OUTPUT_EVERYTHING;
+    if (outputBuffer->data)
+        free(outputBuffer->data);
+    outputBuffer->data = tmp;
     return true;
 }
 


### PR DESCRIPTION
re-alloc a new bigger output buffer for the encoded picture size is
larger than the default.

to fix issue [#657](https://github.com/01org/libyami/issues/657)

Signed-off-by: wudping <dongpingx.wu@intel.com>