### PR TITLE
avformat: be compatible with all version ffmpeg

### DIFF
--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -22,6 +22,10 @@
 #include "common/log.h"
 #include <Yami.h>
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 39, 100)
+#define av_packet_unref av_free_packet
+#endif
+
 DecodeInputAvFormat::DecodeInputAvFormat()
 :m_format(NULL),m_videoId(-1), m_codecId(AV_CODEC_ID_NONE), m_isEos(true)
 {
@@ -103,7 +107,9 @@ static const MimeEntry MimeEntrys[] = {
 #endif
 
     AV_CODEC_ID_H264, YAMI_MIME_H264,
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 39, 100)
     AV_CODEC_ID_H265, YAMI_MIME_H265,
+#endif
     AV_CODEC_ID_WMV3, YAMI_MIME_VC1,
     AV_CODEC_ID_VC1, YAMI_MIME_VC1
 };


### PR DESCRIPTION
The old version ffmpeg does't support HEVC, and does't have the API
av_packet_unref(). So add some MACRO to make yami-utils can be compatible
with all the version of FFMPEG.

to fix #73 

Signed-off-by: wudping <dongpingx.wu@intel.com>