### PR TITLE
Use zero copy api in v4l2 decoder

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -106,7 +106,7 @@ yamiencode_SOURCES  = encode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInp
 
 v4l2decode_LDADD   = $(V4L2_DECODE_LIBS)
 v4l2decode_LDFLAGS = $(V4L2_DECODE_LDFLAGS)
-v4l2decode_SOURCES = v4l2decode.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES)
+v4l2decode_SOURCES = v4l2decode.cpp V4L2Device.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES)
 
 if ENABLE_TESTS_GLES
 v4l2decode_SOURCES += ./egl/gles2_help.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -106,7 +106,7 @@ yamiencode_SOURCES  = encode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInp
 
 v4l2decode_LDADD   = $(V4L2_DECODE_LIBS)
 v4l2decode_LDFLAGS = $(V4L2_DECODE_LDFLAGS)
-v4l2decode_SOURCES = v4l2decode.cpp V4L2Device.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES)
+v4l2decode_SOURCES = v4l2decode.cpp V4L2Renderer.cpp V4L2Device.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES)
 
 if ENABLE_TESTS_GLES
 v4l2decode_SOURCES += ./egl/gles2_help.c

--- a/tests/V4L2Device.cpp
+++ b/tests/V4L2Device.cpp
@@ -45,7 +45,8 @@ struct TypeEntry {
 const static TypeEntry g_entrys[] = {
     { VIDEO_DATA_MEMORY_TYPE_DRM_NAME, "drm-name" },
     { VIDEO_DATA_MEMORY_TYPE_DMA_BUF, "dma-buf" },
-    { VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE, "android-buffer-handle" }
+    { VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE, "android-buffer-handle" },
+    { VIDEO_DATA_MEMORY_TYPE_EXTERNAL_DMA_BUF, "external-dma-buf" }
 
 };
 

--- a/tests/V4L2Device.cpp
+++ b/tests/V4L2Device.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "V4L2Device.h"
+
+#include "common/log.h"
+#include "common/common_def.h"
+#include <string.h>
+#include <inttypes.h>
+
+#ifdef __ENABLE_V4L2_OPS__
+
+#include "v4l2codec_device_ops.h"
+#include <dlfcn.h>
+#include <fcntl.h>
+
+#define SIMULATE_V4L2_OP(OP, ...)                      \
+    do {                                               \
+        if (!m_ops.m##OP##Func)                        \
+            return -1;                                 \
+        return m_ops.m##OP##Func(m_fd, ##__VA_ARGS__); \
+    } while (0)
+
+struct TypeEntry {
+    VideoDataMemoryType type;
+    const char* str;
+};
+
+const static TypeEntry g_entrys[] = {
+    { VIDEO_DATA_MEMORY_TYPE_DRM_NAME, "drm-name" },
+    { VIDEO_DATA_MEMORY_TYPE_DMA_BUF, "dma-buf" },
+    { VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE, "android-buffer-handle" }
+
+};
+
+const char* frameTypeToString(VideoDataMemoryType type)
+{
+    for (size_t i = 0; i < N_ELEMENTS(g_entrys); i++) {
+        if (type == g_entrys[i].type)
+            return g_entrys[i].str;
+    }
+    ASSERT(0 && "not support yet");
+    return NULL;
+}
+
+class V4L2DeviceOps : public V4L2Device {
+public:
+    bool open(const char* name, int32_t flags)
+    {
+        if (!m_ops.mOpenFunc)
+            return false;
+        m_fd = m_ops.mOpenFunc(name, flags);
+        return m_fd != -1;
+    }
+
+    int32_t close()
+    {
+        SIMULATE_V4L2_OP(Close);
+    }
+
+    int32_t ioctl(int32_t cmd, void* arg)
+    {
+        SIMULATE_V4L2_OP(Ioctl, cmd, arg);
+    }
+
+    int32_t poll(bool pollDevice, bool* eventPending)
+    {
+        SIMULATE_V4L2_OP(Poll, pollDevice, eventPending);
+    }
+
+    int32_t setDevicePollInterrupt()
+    {
+        SIMULATE_V4L2_OP(SetDevicePollInterrupt);
+    }
+
+    int32_t clearDevicePollInterrupt()
+    {
+        SIMULATE_V4L2_OP(ClearDevicePollInterrupt);
+    }
+
+    void* mmap(void* addr, size_t length, int32_t prot,
+        int32_t flags, unsigned int offset)
+    {
+        if (!m_ops.mMmapFunc)
+            return NULL;
+
+        return m_ops.mMmapFunc(addr, length, prot, flags, m_fd, offset);
+    }
+
+    int32_t munmap(void* addr, size_t length)
+    {
+        if (!m_ops.mMunmapFunc)
+            return -1;
+
+        return m_ops.mMunmapFunc(addr, length);
+    }
+
+    int32_t setFrameMemoryType(VideoDataMemoryType type)
+    {
+        const char* str = frameTypeToString(type);
+        if (str)
+            SIMULATE_V4L2_OP(SetParameter, "frame-memory-type", str);
+        return -1;
+    }
+
+#if __ENABLE_TESTS_GLES__
+    int32_t useEglImage(/*EGLDisplay*/ void* eglDisplay, /*EGLContext*/ void* eglContext,
+        uint32_t bufferIndex, void* eglImage)
+    {
+        SIMULATE_V4L2_OP(UseEglImage, eglDisplay, eglContext, bufferIndex, eglImage);
+    }
+
+    int32_t setDrmFd(int drmFd)
+    {
+        ASSERT(0 && "not supported yet");
+        return -1;
+    }
+#endif
+
+#if __ENABLE_WAYLAND__
+    int32_t setWaylandDisplay(struct wl_display* wlDisplay)
+    {
+        char displayStr[32];
+        sprintf(displayStr, "%" PRIu64 "", (uint64_t)(wlDisplay));
+        SIMULATE_V4L2_OP(SetParameter, "wayland-display", displayStr);
+    }
+#endif
+
+#if __ENABLE_X11__
+    /// it should be called before driver initialization (immediate after _Open()).
+    int32_t setXDisplay(Display* x11Display)
+    {
+        char displayStr[32];
+        sprintf(displayStr, "%" PRIu64 "", (uint64_t)x11Display);
+        SIMULATE_V4L2_OP(SetParameter, "x11-display", displayStr);
+    }
+#endif
+
+    V4L2DeviceOps()
+        : m_handle(NULL)
+    {
+        memset(&m_ops, 0, sizeof(m_ops));
+    }
+
+    ~V4L2DeviceOps()
+    {
+        if (m_handle)
+            dlclose(m_handle);
+    }
+
+protected:
+    bool init()
+    {
+        const char* libName = "libyami_v4l2.so";
+        m_handle = dlopen(libName, RTLD_NOW | RTLD_GLOBAL);
+        if (!m_handle) {
+            ERROR("dlopen failed for %s", libName);
+            return false;
+        }
+
+        V4l2codecOperationInitFunc initFunc = NULL;
+        initFunc = (V4l2codecOperationInitFunc)dlsym(RTLD_DEFAULT, "v4l2codecOperationInit");
+
+        if (!initFunc) {
+            ERROR("fail to dlsym v4l2codecOperationInit\n");
+            return false;
+        }
+
+        INIT_V4L2CODEC_OPS_SIZE_VERSION(&m_ops);
+        if (!initFunc(&m_ops)) {
+            ERROR("fail to init v4l2 device operation func pointers\n");
+            return false;
+        }
+
+        int isVersionMatch = 0;
+        IS_V4L2CODEC_OPS_VERSION_MATCH(m_ops.mVersion, isVersionMatch);
+        if (!isVersionMatch) {
+            ERROR("V4l2CodecOps interface version doesn't match\n");
+            return false;
+        }
+        if (m_ops.mSize != sizeof(V4l2CodecOps)) {
+            ERROR("V4l2CodecOps interface data structure size doesn't match\n");
+            return false;
+        }
+        return true;
+    }
+
+private:
+    void* m_handle;
+    V4l2CodecOps m_ops;
+};
+#undef SIMULATE_V4L2_OP
+
+#else
+
+#include "common/v4l2_wrapper.h"
+
+class V4L2DeviceYami : public V4L2Device {
+public:
+    bool open(const char* name, int32_t flags)
+    {
+        m_fd = YamiV4L2_Open(name, flags);
+        return m_fd != -1;
+    }
+    int32_t close()
+    {
+        return YamiV4L2_Close(m_fd);
+    }
+    int32_t ioctl(int32_t cmd, void* arg)
+    {
+        return YamiV4L2_Ioctl(m_fd, cmd, arg);
+    }
+    int32_t poll(bool pollDevice, bool* eventPending)
+    {
+        return YamiV4L2_Poll(m_fd, pollDevice, eventPending);
+    }
+    int32_t setDevicePollInterrupt()
+    {
+        return YamiV4L2_SetDevicePollInterrupt(m_fd);
+    }
+    int32_t clearDevicePollInterrupt()
+    {
+        return YamiV4L2_ClearDevicePollInterrupt(m_fd);
+    }
+    void* mmap(void* addr, size_t length, int32_t prot,
+        int32_t flags, unsigned int offset)
+    {
+        return YamiV4L2_Mmap(addr, length, prot, flags, m_fd, offset);
+    }
+    int32_t munmap(void* addr, size_t length)
+    {
+        return YamiV4L2_Munmap(addr, length);
+    }
+    int32_t setFrameMemoryType(VideoDataMemoryType type)
+    {
+        return YamiV4L2_FrameMemoryType(m_fd, type);
+    }
+
+#if __ENABLE_TESTS_GLES__
+    int32_t useEglImage(/*EGLDisplay*/ void* eglDisplay, /*EGLContext*/ void* eglContext,
+        uint32_t bufferIndex, void* eglImage)
+    {
+        return YamiV4L2_UseEglImage(m_fd, eglDisplay, eglContext, bufferIndex, eglImage);
+    }
+    int32_t setDrmFd(int drmFd)
+    {
+        return YamiV4L2_SetDrmFd(m_fd, drmFd);
+    }
+#endif
+
+#if __ENABLE_WAYLAND__
+    int32_t setWaylandDisplay(struct wl_display* wlDisplay)
+    {
+        return YamiV4L2_SetWaylandDisplay(m_fd, wlDisplay);
+    }
+#endif
+
+#if __ENABLE_X11__
+    /// it should be called before driver initialization (immediate after _Open()).
+    int32_t setXDisplay(Display* x11Display)
+    {
+        return YamiV4L2_SetXDisplay(m_fd, x11Display);
+    }
+#endif
+
+protected:
+    bool init()
+    {
+        return true;
+    }
+};
+#endif //__ENABLE_V4L2_OPS__
+
+SharedPtr<V4L2Device> V4L2Device::Create()
+{
+    SharedPtr<V4L2Device> device;
+#ifdef __ENABLE_V4L2_OPS__
+    device.reset(new V4L2DeviceOps);
+#else
+    device.reset(new V4L2DeviceYami);
+#endif
+    if (!device->init())
+        device.reset();
+    return device;
+}

--- a/tests/V4L2Device.h
+++ b/tests/V4L2Device.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef V4L2Device_h
+#define V4L2Device_h
+
+#include <VideoCommonDefs.h>
+#if __ENABLE_X11__
+#include <X11/Xlib.h>
+#endif
+
+#if __ENABLE_TESTS_GLES__
+#include <EGL/egl.h>
+#endif
+
+class V4L2Device {
+public:
+    static SharedPtr<V4L2Device> Create();
+    virtual bool open(const char* name, int32_t flags) = 0;
+    virtual int32_t close() = 0;
+    virtual int32_t ioctl(int32_t cmd, void* arg) = 0;
+    virtual int32_t poll(bool pollDevice, bool* eventPending) = 0;
+    virtual int32_t setDevicePollInterrupt() = 0;
+    virtual int32_t clearDevicePollInterrupt() = 0;
+    virtual void* mmap(void* addr, size_t length, int32_t prot,
+        int32_t flags, unsigned int offset)
+        = 0;
+    virtual int32_t munmap(void* addr, size_t length) = 0;
+    virtual int32_t setFrameMemoryType(VideoDataMemoryType memory_type) = 0;
+
+#if __ENABLE_TESTS_GLES__
+    virtual int32_t useEglImage(/*EGLDisplay*/ void* eglDisplay, /*EGLContext*/ void* eglContext,
+        uint32_t bufferIndex, void* eglImage)
+        = 0;
+    virtual int32_t setDrmFd(int drmFd) = 0;
+#endif
+
+#if __ENABLE_WAYLAND__
+    virtual int32_t setWaylandDisplay(struct wl_display* wlDisplay) = 0;
+#endif
+
+#if __ENABLE_X11__
+    /// it should be called before driver initialization (immediate after _Open()).
+    virtual int32_t setXDisplay(Display* x11Display) = 0;
+#endif
+protected:
+    virtual bool init() = 0;
+    int m_fd;
+};
+
+#endif

--- a/tests/V4L2Renderer.cpp
+++ b/tests/V4L2Renderer.cpp
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) 2011-2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "V4L2Device.h"
+#include "common/log.h"
+#include "vaapi/vaapidisplay.h"
+#include "common/VaapiUtils.h"
+
+#include <vector>
+#include <deque>
+#include <algorithm>
+#include <string.h>
+#include <linux/videodev2.h>
+
+#include "V4L2Renderer.h"
+
+const static uint32_t kExtraOutputFrameCount = 2;
+const static uint32_t kOutputPlaneCount = 2;
+const static uint32_t kMaxOutputPlaneCount = 3;
+
+using namespace YamiMediaCodec;
+
+V4L2Renderer::V4L2Renderer(const SharedPtr<V4L2Device>& device, VideoDataMemoryType memoryType)
+    : m_device(device)
+    , m_memoryType(memoryType)
+{
+}
+
+bool V4L2Renderer::renderOneFrame()
+{
+    uint32_t index;
+    bool ret;
+    ret = dequeBuffer(index);
+    if (!ret)
+        return false;
+    ret = render(index);
+    ASSERT(ret && "render failed");
+    ret = queueBuffer(index);
+    ASSERT(ret && "queue buffer failed");
+    return true;
+}
+
+bool V4L2Renderer::queueBuffer(uint32_t index, unsigned long userptr)
+{
+    struct v4l2_buffer buf;
+    struct v4l2_plane planes[kMaxOutputPlaneCount]; // YUV output, in fact, we use NV12 of 2 planes
+    int ioctlRet = -1;
+
+    memset(&buf, 0, sizeof(buf));
+    memset(&planes, 0, sizeof(planes));
+    buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE; //it indicates output buffer type
+    buf.memory = V4L2_MEMORY_MMAP;
+    buf.index = index;
+    buf.m.planes = planes;
+    buf.m.userptr = userptr;
+    buf.length = kOutputPlaneCount;
+    ioctlRet = m_device->ioctl(VIDIOC_QBUF, &buf);
+    ASSERT(ioctlRet != -1);
+    return true;
+}
+
+bool V4L2Renderer::dequeBuffer(uint32_t& index)
+{
+    struct v4l2_buffer buf;
+    struct v4l2_plane planes[kMaxOutputPlaneCount]; // YUV output, in fact, we use NV12 of 2 planes
+    int ioctlRet = -1;
+
+    memset(&buf, 0, sizeof(buf));
+    memset(&planes, 0, sizeof(planes));
+    buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE; //it indicates output buffer type
+    buf.memory = V4L2_MEMORY_MMAP;
+    buf.m.planes = planes;
+    buf.length = kOutputPlaneCount;
+
+    ioctlRet = m_device->ioctl(VIDIOC_DQBUF, &buf);
+    if (ioctlRet == -1)
+        return false;
+    index = buf.index;
+    return true;
+}
+
+bool V4L2Renderer::getDpbSize(uint32_t& dpbSize)
+{
+    // setup output buffers
+    // Number of output buffers we need.
+    struct v4l2_control ctrl;
+    memset(&ctrl, 0, sizeof(ctrl));
+    ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_CAPTURE;
+    int32_t ioctlRet = m_device->ioctl(VIDIOC_G_CTRL, &ctrl);
+    ASSERT(ioctlRet != -1);
+    dpbSize = ctrl.value;
+    return true;
+}
+
+bool V4L2Renderer::requestBuffers(uint32_t& count)
+{
+    struct v4l2_requestbuffers reqbufs;
+
+    memset(&reqbufs, 0, sizeof(reqbufs));
+    reqbufs.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+    reqbufs.memory = V4L2_MEMORY_MMAP;
+    reqbufs.count = count;
+    int32_t ioctlRet = m_device->ioctl(VIDIOC_REQBUFS, &reqbufs);
+    ASSERT(ioctlRet != -1);
+    ASSERT(reqbufs.count > 0);
+    count = reqbufs.count;
+    return true;
+}
+
+#ifdef __ENABLE_X11__
+#include <X11/Xlib.h>
+class X11Renderer : public V4L2Renderer {
+public:
+    X11Renderer(const SharedPtr<V4L2Device>& device, VideoDataMemoryType memoryType)
+        : V4L2Renderer(device, memoryType)
+        , m_x11Display(NULL)
+        , m_x11Window(0)
+    {
+    }
+    bool setDisplay()
+    {
+        XInitThreads();
+        m_x11Display = XOpenDisplay(NULL);
+        ASSERT(m_x11Display);
+        DEBUG("x11display: %p", m_x11Display);
+        int32_t ioctlRet = m_device->setXDisplay(m_x11Display);
+        return ioctlRet != -1;
+    }
+    bool queueOutputBuffersAtStart(uint32_t count)
+    {
+        for (uint32_t i = 0; i < count; i++) {
+            if (!queueBuffer(i)) {
+                ASSERT(0);
+            }
+        }
+        return true;
+    }
+
+protected:
+    bool createWindow(uint32_t width, uint32_t height)
+    {
+        if (m_x11Window)
+            return true;
+        m_x11Window = XCreateSimpleWindow(m_x11Display, DefaultRootWindow(m_x11Display), 0, 0, width, height, 0, 0, WhitePixel(m_x11Display, 0));
+        if (m_x11Window <= 0)
+            return false;
+        XMapWindow(m_x11Display, m_x11Window);
+        return true;
+    }
+    Display* m_x11Display;
+    Window m_x11Window;
+};
+
+#include <va/va.h>
+#include <va/va_drmcommon.h>
+class ExternalDmaBufRenderer : public X11Renderer {
+    const static uint32_t kFrontSize = 3;
+
+public:
+    ExternalDmaBufRenderer(const SharedPtr<V4L2Device>& device, VideoDataMemoryType memoryType)
+        : X11Renderer(device, memoryType)
+        , m_width(0)
+        , m_height(0)
+    {
+    }
+    bool setDisplay()
+    {
+        XInitThreads();
+        m_x11Display = XOpenDisplay(NULL);
+        ASSERT(m_x11Display);
+        DEBUG("x11display: %p", m_x11Display);
+
+        NativeDisplay native;
+        memset(&native, 0, sizeof(native));
+        native.handle = (intptr_t)m_x11Display;
+        native.type = NATIVE_DISPLAY_X11;
+        m_display = VaapiDisplay::create(native);
+        ASSERT(bool(m_display));
+        return true;
+    }
+
+    bool setupOutputBuffers(uint32_t width, uint32_t height)
+    {
+        if (!createWindow(width, height)) {
+            ERROR("Create window failed");
+            return false;
+        }
+        uint32_t dpbSize;
+        if (!getDpbSize(dpbSize)) {
+            ERROR("get dpb size failed");
+            return false;
+        }
+        uint32_t count = dpbSize + kExtraOutputFrameCount + kFrontSize;
+        if (!requestBuffers(count)) {
+            ERROR("requestBuffers failed");
+            return false;
+        }
+        m_width = width;
+        m_height = height;
+        return setupOutputBuffers(width, height, count) && queueOutputBuffersAtStart(count);
+    }
+
+    bool queueOutputBuffersAtStart(uint32_t count)
+    {
+        for (uint32_t i = 0; i < count; i++) {
+            if (!queueBuffer(i, (unsigned long)m_dmabuf[i])) {
+                ASSERT(0);
+            }
+            releaseBufferHandle(m_images[i]);
+        }
+        for (uint32_t i = 0; i < kFrontSize; i++) {
+            uint32_t index;
+            if (!dequeBuffer(index)) {
+                ASSERT(0);
+            }
+            m_front.push_back(index);
+        }
+        return true;
+    }
+
+    bool queueOutputBuffers()
+    {
+        for (size_t i = 0; i < m_dmabuf.size(); i++) {
+            if (std::find(m_front.begin(), m_front.end(), i) == m_front.end()) {
+                if (!queueBuffer(i)) {
+                    ASSERT(0);
+                }
+            }
+        }
+        return true;
+    }
+    ~ExternalDmaBufRenderer()
+    {
+        if (m_surfaces.size()) {
+            vaDestroySurfaces(m_display->getID(), &m_surfaces[0], m_surfaces.size());
+        }
+    }
+
+private:
+    bool acquireBufferHandle(uintptr_t& handle, VAImage& image, VASurfaceID surface)
+    {
+        if (!checkVaapiStatus(vaDeriveImage(m_display->getID(), surface, &image), "DeriveImage"))
+            return false;
+        VABufferInfo bufferInfo;
+        bufferInfo.mem_type = VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME;
+        if (!checkVaapiStatus(vaAcquireBufferHandle(m_display->getID(), image.buf, &bufferInfo), "AcquireBufferHandle")) {
+            checkVaapiStatus(vaDestroyImage(m_display->getID(), image.image_id), "vaDestroyImage");
+            return false;
+        }
+        handle = bufferInfo.handle;
+        return true;
+    }
+    bool releaseBufferHandle(VAImage& image)
+    {
+        checkVaapiStatus(vaReleaseBufferHandle(m_display->getID(), image.buf), "ReleaseBufferHandle");
+        checkVaapiStatus(vaDestroyImage(m_display->getID(), image.image_id), "vaDestroyImage");
+        return true;
+    }
+    bool setSurfaceInfo(VASurfaceID surface)
+    {
+        VAImage image;
+        if (!checkVaapiStatus(vaDeriveImage(m_display->getID(), surface, &image), "DeriveImage"))
+            return false;
+        struct v4l2_create_buffers createBuffers;
+        memset(&createBuffers, 0, sizeof(createBuffers));
+        v4l2_pix_format_mplane& format = createBuffers.format.fmt.pix_mp;
+        format.pixelformat = image.format.fourcc;
+        format.width = image.width;
+        format.height = image.height;
+        format.num_planes = image.num_planes;
+        for (uint32_t i = 0; i < format.num_planes; i++) {
+            format.plane_fmt[i].bytesperline = image.pitches[i];
+            //not really right, but we use sizeimage to deliver offset
+            format.plane_fmt[i].sizeimage = image.offsets[i];
+        }
+        int32_t ioctlRet = m_device->ioctl(VIDIOC_CREATE_BUFS, &createBuffers);
+        checkVaapiStatus(vaDestroyImage(m_display->getID(), image.image_id), "vaDestroyImage");
+        return ioctlRet != -1;
+    }
+    bool setupOutputBuffers(uint32_t width, uint32_t height, uint32_t count)
+    {
+        m_surfaces.resize(count);
+
+        VASurfaceAttrib attrib;
+        uint32_t rtFormat = VA_RT_FORMAT_YUV420;
+        int pixelFormat = VA_FOURCC_NV12;
+        attrib.type = VASurfaceAttribPixelFormat;
+        attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
+        attrib.value.type = VAGenericValueTypeInteger;
+        attrib.value.value.i = pixelFormat;
+        VAStatus status;
+        status = vaCreateSurfaces(m_display->getID(), rtFormat,
+            width, height, &m_surfaces[0], count, &attrib, 1);
+        ASSERT(status == VA_STATUS_SUCCESS);
+        ASSERT(setSurfaceInfo(m_surfaces[0]));
+        m_dmabuf.resize(count);
+        m_images.resize(count);
+        for (uint32_t i = 0; i < count; i++) {
+            if (!acquireBufferHandle(m_dmabuf[i], m_images[i], m_surfaces[i]))
+                ASSERT(0);
+        }
+        return true;
+    }
+    void addAndPopFront(uint32_t& index)
+    {
+        m_front.push_back(index);
+        index = m_front.front();
+        m_front.pop_front();
+    }
+    bool render(uint32_t& index)
+    {
+        ASSERT(index < m_surfaces.size());
+        VASurfaceID s = m_surfaces[index];
+        VAStatus status = vaPutSurface(m_display->getID(), s,
+            m_x11Window, 0, 0, m_width, m_height,
+            0, 0, m_width, m_height,
+            NULL, 0, 0);
+        bool ret = checkVaapiStatus(status, "vaPutSurface");
+
+        addAndPopFront(index);
+        return ret;
+    }
+    DisplayPtr m_display;
+    std::vector<VASurfaceID> m_surfaces;
+    std::vector<uintptr_t> m_dmabuf;
+    std::vector<VAImage> m_images;
+    std::deque<uint32_t> m_front;
+    uint32_t m_width;
+    uint32_t m_height;
+};
+
+#ifdef __ENABLE_TESTS_GLES__ //our egl application need x11 for output
+
+#include "./egl/gles2_help.h"
+
+class EglRenderer : public X11Renderer {
+public:
+    EglRenderer(const SharedPtr<V4L2Device>& device, VideoDataMemoryType memoryType)
+        : X11Renderer(device, memoryType)
+        , m_eglContext(NULL)
+    {
+    }
+    bool setupOutputBuffers(uint32_t width, uint32_t height)
+    {
+        if (!createWindow(width, height)) {
+            ERROR("Create window failed");
+            return false;
+        }
+        uint32_t dpbSize;
+        if (!getDpbSize(dpbSize)) {
+            ERROR("get dpb size failed");
+            return false;
+        }
+        uint32_t count = dpbSize + kExtraOutputFrameCount;
+        if (!requestBuffers(count)) {
+            ERROR("requestBuffers failed");
+            return false;
+        }
+        return setupOutputBuffers(count) && queueOutputBuffersAtStart(count);
+    }
+    bool render(uint32_t& idx)
+    {
+        const uint32_t index = idx;
+        ASSERT(m_eglContext && m_textureIds.size());
+        ASSERT(index >= 0 && index < m_textureIds.size());
+        DEBUG("textureIds[%d] = 0x%x", index, m_textureIds[index]);
+        GLenum target = GL_TEXTURE_2D;
+        if (isDmaBuf())
+            target = GL_TEXTURE_EXTERNAL_OES;
+        int ret = drawTextures(m_eglContext, target, &m_textureIds[index], 1);
+
+        return ret == 0;
+    }
+    ~EglRenderer()
+    {
+        if (m_textureIds.size())
+            glDeleteTextures(m_textureIds.size(), &m_textureIds[0]);
+        ASSERT(glGetError() == GL_NO_ERROR);
+        for (size_t i = 0; i < m_eglImages.size(); i++) {
+            destroyImage(m_eglContext->eglContext.display, m_eglImages[i]);
+        }
+        /*
+        there is still randomly fail in mesa; no good idea for it. seems mesa bug
+        0  0x00007ffff079c343 in _mesa_symbol_table_dtor () from /usr/lib/x86_64-linux-gnu/libdricore9.2.1.so.1
+        1  0x00007ffff073c55d in glsl_symbol_table::~glsl_symbol_table() () from /usr/lib/x86_64-linux-gnu/libdricore9.2.1.so.1
+        2  0x00007ffff072a4d5 in ?? () from /usr/lib/x86_64-linux-gnu/libdricore9.2.1.so.1
+        3  0x00007ffff072a4bd in ?? () from /usr/lib/x86_64-linux-gnu/libdricore9.2.1.so.1
+        4  0x00007ffff064b48f in _mesa_reference_shader () from /usr/lib/x86_64-linux-gnu/libdricore9.2.1.so.1
+        5  0x00007ffff0649397 in ?? () from /usr/lib/x86_64-linux-gnu/libdricore9.2.1.so.1
+        6  0x000000000040624d in releaseShader (program=0x77cd90) at ./egl/gles2_help.c:158
+        7  eglRelease (context=0x615920) at ./egl/gles2_help.c:310
+        8  0x0000000000402ca8 in main (argc=<optimized out>, argv=<optimized out>) at v4l2decode.cpp:531
+        */
+        if (m_eglContext)
+            eglRelease(m_eglContext);
+        if (m_x11Window)
+            XDestroyWindow(m_x11Display, m_x11Window);
+    }
+
+private:
+    bool setupOutputBuffers(uint32_t count)
+    {
+        m_textureIds.resize(count);
+        // setup all textures and eglImages
+
+        if (!m_eglContext)
+            m_eglContext = eglInit(m_x11Display, m_x11Window, 0 /*VA_FOURCC_RGBA*/, isDmaBuf());
+
+        m_eglImages.resize(count);
+        glGenTextures(count, &m_textureIds[0]);
+        for (uint32_t i = 0; i < count; i++) {
+            int ret = 0;
+            ret = m_device->useEglImage(m_eglContext->eglContext.display, m_eglContext->eglContext.context, i, &m_eglImages[i]);
+            ASSERT(ret == 0);
+
+            GLenum target = GL_TEXTURE_2D;
+            if (isDmaBuf())
+                target = GL_TEXTURE_EXTERNAL_OES;
+            glBindTexture(target, m_textureIds[i]);
+            imageTargetTexture2D(target, m_eglImages[i]);
+
+            glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            DEBUG("textureIds[%d]: 0x%x, eglImages[%d]: 0x%p", i, m_textureIds[i], i, m_eglImages[i]);
+        }
+        return true;
+    }
+
+    bool isDmaBuf()
+    {
+        return m_memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF;
+    }
+
+    bool queueOutputBuffers()
+    {
+        return queueOutputBuffersAtStart((uint32_t)m_eglImages.size());
+    }
+
+    EGLContextType* m_eglContext;
+    std::vector<EGLImageKHR> m_eglImages;
+    std::vector<GLuint> m_textureIds;
+};
+
+#endif
+
+#endif
+
+SharedPtr<V4L2Renderer> V4L2Renderer::create(const SharedPtr<V4L2Device>& device, VideoDataMemoryType memoryType)
+{
+    SharedPtr<V4L2Renderer> renderer;
+#ifdef __ENABLE_X11__
+    if (memoryType == VIDEO_DATA_MEMORY_TYPE_EXTERNAL_DMA_BUF)
+        renderer.reset(new ExternalDmaBufRenderer(device, memoryType));
+#ifdef __ENABLE_TESTS_GLES__
+    if (memoryType == VIDEO_DATA_MEMORY_TYPE_DRM_NAME || memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF)
+        renderer.reset(new EglRenderer(device, memoryType));
+#endif
+#endif
+
+    return renderer;
+}

--- a/tests/V4L2Renderer.h
+++ b/tests/V4L2Renderer.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2011-2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <Yami.h>
+
+class V4L2Device;
+class V4L2Renderer {
+public:
+    static SharedPtr<V4L2Renderer> create(const SharedPtr<V4L2Device>&, VideoDataMemoryType memoryType);
+    virtual bool setDisplay() = 0;
+    virtual bool setupOutputBuffers(uint32_t wdith, uint32_t height) = 0;
+    bool renderOneFrame();
+    virtual bool queueOutputBuffers() = 0;
+
+protected:
+    V4L2Renderer(const SharedPtr<V4L2Device>&, VideoDataMemoryType memoryType);
+    bool getDpbSize(uint32_t& dpbSize);
+    bool requestBuffers(uint32_t& count);
+    bool queueBuffer(uint32_t index, unsigned long userptr = 0);
+    bool dequeBuffer(uint32_t& index);
+    virtual bool render(uint32_t& index) = 0;
+    virtual bool queueOutputBuffersAtStart(uint32_t count) = 0;
+
+    SharedPtr<V4L2Device> m_device;
+    VideoDataMemoryType m_memoryType;
+};

--- a/tests/decodehelp.cpp
+++ b/tests/decodehelp.cpp
@@ -43,12 +43,13 @@ static void printHelp(const char* app)
     printf("   -m <render mode>\n");
     printf("     -2: print MD5 by per frame and the whole decoded file MD5\n");
     printf("     -1: skip video rendering [*]\n");
-    printf("      0: dump video frame to file\n");
+    printf("      0: dump video frame to file [*]\n");
     printf("      1: render to X window [*]\n");
     printf("      2: texture: render to Pixmap + texture from Pixmap [*]\n");
     printf("      3: texture: export video frame as drm name (RGBX) + texture from drm name\n");
     printf("      4: texture: export video frame as dma_buf(RGBX) + texutre from dma_buf\n");
     printf("      5: texture: export video frame as dma_buf(NV12) + texture from dma_buf. not implement yet\n");
+    printf("      6: use external dma buf for decode and display, only v4l2decode support this\n");
     printf(" [*] v4l2decode doesn't support the option\n");
     printf("  --capi: use the codec capi to encode or decode, default(false)\n");
 }

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -710,7 +710,7 @@ int main(int argc, char** argv)
     memset(&reqbufs, 0, sizeof(reqbufs));
     reqbufs.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
     reqbufs.memory = inputMemoryType;
-    reqbufs.count = 2;
+    reqbufs.count = 8;
     ioctlRet = SIMULATE_V4L2_OP(Ioctl)(fd, VIDIOC_REQBUFS, &reqbufs);
     ASSERT(ioctlRet != -1);
     ASSERT(reqbufs.count>0);

--- a/vaapi/vaapidisplay.h
+++ b/vaapi/vaapidisplay.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef vaapidisplay_h
+#define vaapidisplay_h
+
+#include <va/va.h>
+#include <va/va_tpi.h>
+#ifdef HAVE_VA_X11
+#include <va/va_x11.h>
+#endif
+#ifndef ANDROID
+#include <va/va_drm.h>
+#endif
+#include <vector>
+#include "common/lock.h"
+#include "common/NonCopyable.h"
+
+///abstract for all display, x11, wayland, ozone, android etc.
+namespace YamiMediaCodec {
+#ifndef VA_FOURCC_I420
+#define VA_FOURCC_I420 VA_FOURCC('I', '4', '2', '0')
+#endif
+class NativeDisplayBase;
+class VaapiDisplay;
+typedef SharedPtr<VaapiDisplay> DisplayPtr;
+class VaapiDisplay {
+    typedef SharedPtr<NativeDisplayBase> NativeDisplayPtr;
+    friend class DisplayCache;
+    friend class VaapiDisplayTest;
+
+public:
+    virtual ~VaapiDisplay();
+    //FIXME: add more create functions.
+    static DisplayPtr create(const NativeDisplay& display);
+    virtual bool setRotation(int degree);
+    VADisplay getID() const { return m_vaDisplay; }
+    const VAImageFormat* getVaFormat(uint32_t fourcc);
+
+protected:
+    /// for display cache management.
+    virtual bool isCompatible(const NativeDisplay& other);
+
+private:
+    VaapiDisplay(const NativeDisplayPtr& nativeDisplay, VADisplay vaDisplay)
+        : m_vaDisplay(vaDisplay)
+        , m_nativeDisplay(nativeDisplay){};
+
+    Lock m_lock;
+    VADisplay m_vaDisplay;
+    NativeDisplayPtr m_nativeDisplay;
+    std::vector<VAImageFormat> m_vaImageFormats;
+
+    DISALLOW_COPY_AND_ASSIGN(VaapiDisplay);
+};
+}
+#endif


### PR DESCRIPTION
The main target of this pull request is enabling zero copy feature in v4l2decoder. But it does more things beyond this. Current v4l2decoder is a little mess. It full of duplicate and full of #ifdef. It's hard to make it even buildable. So before I add zero copy patch. I use some patch to refact the v4l2decoder to make it more readable.