### PR TITLE
README: add coverity label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-#libyami-utils
-Applications and Scripts for libyami.
-You can find libyami in https://github.com/01org/libyami
+[![Build Status](https://travis-ci.org/01org/libyami-utils.svg?branch=master)](https://travis-ci.org/01org/libyami-utils)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/11605/badge.svg)](https://scan.coverity.com/projects/01org-libyami-utils)
 
-* Copyright (C) 2011-2016 Intel Corporation
+
+libyami-utils
+-------------
+Applications and Scripts for libyami.
+
+You can find libyami in https://github.com/01org/libyami
+  * Copyright (C) 2011-2016 Intel Corporation
+
 
 License
 -------
@@ -14,15 +20,14 @@ Overview
 --------
 libyami-utils consists of directories
 
-    * 'tests': sample decoder/encoder/vpp applications
-    * 'testscripts': conformance test scripts
-    * 'examples': simpleplayer and video wall demo
+  * `tests`: sample decoder/encoder/vpp applications
+  * `testscripts`: conformance test scripts
+  * `examples`: simpleplayer and video wall demo
 
 
 Requirements
 ------------
 Hardware requirements
-
   * Intel (core) Sandybridge, Ivybridge, Haswell, Broadwell, Skylake, Kabylake
   * Intel (atom) Baytrail, Braswell, Apollolake
 


### PR DESCRIPTION
add two label for build and coverity in README.md.

to implement [VIZ-9125](https://jira01.devtools.intel.com/browse/VIZ-9125) based on Yizhou's code.

Signed-off-by: wudping <dongpingx.wu@intel.com>