### PR TITLE
v4l2: add virtual destructor and check NULL point

### DIFF
--- a/tests/V4L2Renderer.cpp
+++ b/tests/V4L2Renderer.cpp
@@ -245,7 +245,7 @@ public:
         }
         return true;
     }
-    ~ExternalDmaBufRenderer()
+    virtual ~ExternalDmaBufRenderer()
     {
         if (m_surfaces.size()) {
             vaDestroySurfaces(m_display->getID(), &m_surfaces[0], m_surfaces.size());
@@ -387,7 +387,7 @@ public:
 
         return ret == 0;
     }
-    ~EglRenderer()
+    virtual ~EglRenderer()
     {
         if (m_textureIds.size())
             glDeleteTextures(m_textureIds.size(), &m_textureIds[0]);
@@ -419,9 +419,11 @@ private:
         m_textureIds.resize(count);
         // setup all textures and eglImages
 
-        if (!m_eglContext)
+        if (!m_eglContext) {
             m_eglContext = eglInit(m_x11Display, m_x11Window, 0 /*VA_FOURCC_RGBA*/, isDmaBuf());
-
+            if (!m_eglContext)
+                return false;
+        }
         m_eglImages.resize(count);
         glGenTextures(count, &m_textureIds[0]);
         for (uint32_t i = 0; i < count; i++) {

--- a/tests/V4L2Renderer.h
+++ b/tests/V4L2Renderer.h
@@ -28,6 +28,7 @@ public:
 
 protected:
     V4L2Renderer(const SharedPtr<V4L2Device>&, VideoDataMemoryType memoryType);
+    virtual ~V4L2Renderer(){};
     bool getDpbSize(uint32_t& dpbSize);
     bool requestBuffers(uint32_t& count);
     bool queueBuffer(uint32_t index, unsigned long userptr = 0);

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -73,7 +73,7 @@ static uint32_t renderFrameCount = 0;
 
 static DecodeParameter params;
 
-bool feedOneInputFrame(DecodeInput* input, const SharedPtr<V4L2Device>& device, int index = -1 /* if index is not -1, simple enque it*/)
+bool feedOneInputFrame(const SharedPtr<DecodeInput>& input, const SharedPtr<V4L2Device>& device, int index = -1 /* if index is not -1, simple enque it*/)
 {
 
     VideoDecodeBuffer inputBuffer;
@@ -157,7 +157,7 @@ extern uint32_t v4l2PixelFormatFromMime(const char* mime);
 
 int main(int argc, char** argv)
 {
-    DecodeInput *input;
+    SharedPtr<DecodeInput> input;
     uint32_t i = 0;
     int32_t ioctlRet = -1;
     YamiMediaCodec::CalcFps calcFps;
@@ -182,9 +182,8 @@ int main(int argc, char** argv)
         ASSERT(0 && "unsupported render mode, -m [0,3,4, 6] are supported");
     break;
     }
-
-    input = DecodeInput::create(params.inputFile);
-    if (input==NULL) {
+    input.reset(DecodeInput::create(params.inputFile));
+    if (!input) {
         ERROR("fail to init input stream\n");
         return -1;
     }
@@ -354,9 +353,8 @@ int main(int argc, char** argv)
 #ifdef SEEK_POS
         frames++;
         if (frames == SEEK_POS) {
-            delete input;
-            input = DecodeInput::create(params.inputFile);
-            if (input == NULL) {
+            input.reset(DecodeInput::create(params.inputFile));
+            if (!input) {
                 ERROR("fail to init input stream\n");
                 return -1;
             }
@@ -424,9 +422,6 @@ int main(int argc, char** argv)
     // close device
     ioctlRet = device->close();
     ASSERT(ioctlRet != -1);
-
-    if(input)
-        delete input;
 
     fprintf(stdout, "decode done\n");
     return 0;


### PR DESCRIPTION
1, define the base class's destructor as virtual.
2, make sure the pointer is not NULL before accessing.

to fix static code scan issue.

Signed-off-by: wudping <dongpingx.wu@intel.com>