### PR TITLE
vp8dec: enable svc-t decoding

### DIFF
--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -41,8 +41,11 @@ SharedPtr<VppInput> createInput(DecodeParameter& para, SharedPtr<NativeDisplay>&
             return input;
     }else{
         SharedPtr<VppInputDecode> inputDecode = DynamicPointerCast<VppInputDecode>(input);
-        if (inputDecode && inputDecode->config(*display))
-            return input;
+        if (inputDecode) {
+            inputDecode->setTargetLayer(para.temporalLayer);
+            if (inputDecode->config(*display))
+                return input;
+        }
     }
     input.reset();
     fprintf(stderr, "VppInputDecode config failed.\n");
@@ -53,6 +56,7 @@ class DecodeTest {
 public:
     bool init(int argc, char** argv)
     {
+        memset(&m_params, 0, sizeof(m_params));
         if (!processCmdLine(argc, argv, &m_params)) {
             fprintf(stderr, "process arguments failed.\n");
             return false;

--- a/tests/decodehelp.cpp
+++ b/tests/decodehelp.cpp
@@ -52,6 +52,9 @@ static void printHelp(const char* app)
     printf("      6: use external dma buf for decode and display, only v4l2decode support this\n");
     printf(" [*] v4l2decode doesn't support the option\n");
     printf("  --capi: use the codec capi to encode or decode, default(false)\n");
+    printf("  --temporal-layer: decode SVC-T stream up to given layer, default 0, only vp8 support\n");
+    printf("      0: decode all layers\n");
+    printf("    N>0: decode the first N layers\n");
 }
 
 bool processCmdLine(int argc, char** argv, DecodeParameter* parameters)
@@ -66,9 +69,11 @@ bool processCmdLine(int argc, char** argv, DecodeParameter* parameters)
     parameters->useCAPI = false;
 
     const struct option long_opts[] = {
-        {"help", no_argument, NULL, 'h'},
-        {"capi", no_argument, NULL, 0},
-        {NULL, no_argument, NULL, 0}};
+        { "help", no_argument, NULL, 'h' },
+        { "capi", no_argument, NULL, 0 },
+        { "temporal-layer", required_argument, NULL, 0 },
+        { NULL, no_argument, NULL, 0 }
+    };
 
     char opt;
     while ((opt = getopt_long_only(argc, argv, "h:m:n:i:f:o:w:?", long_opts,&option_index)) != -1){
@@ -106,6 +111,9 @@ bool processCmdLine(int argc, char** argv, DecodeParameter* parameters)
             switch (option_index) {
             case 1:
                 parameters->useCAPI = true;
+                break;
+            case 2:
+                parameters->temporalLayer = atoi(optarg);
                 break;
             default:
                 printHelp(argv[0]);

--- a/tests/decodehelp.h
+++ b/tests/decodehelp.h
@@ -29,7 +29,10 @@ typedef struct DecodeParameter {
     uint32_t renderFourcc;
     std::string outputFile;
     bool useCAPI;
-} DecodeParameter;
+    uint32_t temporalLayer;
+    uint32_t spacialLayer;
+    uint32_t qualityLayer;
+} StreamParameter;
 
 bool processCmdLine(int argc, char** argv, DecodeParameter* parameters);
 

--- a/tests/vppinputdecode.cpp
+++ b/tests/vppinputdecode.cpp
@@ -42,6 +42,7 @@ bool VppInputDecode::config(NativeDisplay& nativeDisplay)
     }
     configBuffer.width = m_input->getWidth();
     configBuffer.height = m_input->getHeight();
+    configBuffer.temporalLayer = m_temporalLayer;
     Decode_Status status = m_decoder->start(&configBuffer);
     if (status == DECODE_SUCCESS) {
         //read first frame to update width height

--- a/tests/vppinputdecode.h
+++ b/tests/vppinputdecode.h
@@ -32,6 +32,12 @@ public:
     bool read(SharedPtr<VideoFrame>& frame);
 
     bool config(NativeDisplay& nativeDisplay);
+    void setTargetLayer(uint32_t temporal = 0, uint32_t spacial = 0, uint32_t quality = 0)
+    {
+        m_temporalLayer = temporal;
+        m_spacialLayer = spacial;
+        m_qualityLayer = quality;
+    }
     virtual ~VppInputDecode() {}
 private:
     bool m_eos;
@@ -39,6 +45,10 @@ private:
     SharedPtr<IVideoDecoder> m_decoder;
     SharedPtr<DecodeInput>   m_input;
     SharedPtr<VideoFrame>    m_first;
+    //m_xxxLayer layer number, 0: decode all layers, >0: decode up to target layer.
+    uint32_t m_temporalLayer;
+    uint32_t m_spacialLayer;
+    uint32_t m_qualityLayer;
 };
 #endif //vppinputdecode_h
 


### PR DESCRIPTION
Supporting svc-t decodeing for vp8 with max-layer 3.

Signed-off-by: wudping <dongpingx.wu@intel.com>