### PR TITLE
yamidecode: avoid using memset to reset "std::string"

### DIFF
--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -56,7 +56,6 @@ class DecodeTest {
 public:
     bool init(int argc, char** argv)
     {
-        memset(&m_params, 0, sizeof(m_params));
         if (!processCmdLine(argc, argv, &m_params)) {
             fprintf(stderr, "process arguments failed.\n");
             return false;

--- a/tests/decodehelp.cpp
+++ b/tests/decodehelp.cpp
@@ -67,6 +67,9 @@ bool processCmdLine(int argc, char** argv, DecodeParameter* parameters)
     parameters->renderMode = 1;
     parameters->inputFile = NULL;
     parameters->useCAPI = false;
+    parameters->temporalLayer = 0;
+    parameters->spacialLayer = 0;
+    parameters->qualityLayer = 0;
 
     const struct option long_opts[] = {
         { "help", no_argument, NULL, 'h' },


### PR DESCRIPTION
If std::string was set with 0, it can't be assigned a new
value on Ubuntu Trusty.

to fix issue [94](https://github.com/01org/libyami-utils/issues/94)

Signed-off-by: wudping <dongpingx.wu@intel.com>