### PR TITLE
yamiencode: Implement SVC-T encode for VP8

### DIFF
--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -51,7 +51,7 @@ public:
     uint32_t temporalLayerNum; // svc-t temporal layer number
     uint32_t priorityId; // h264 priority_id in prefix nal unit
     EncodeParamsVP9 m_encParamsVP9;
-    uint32_t layerBitRate[4]; // specify each scalable layer bitrate
+    uint32_t layerBitRate[TEMPORAL_LAYER_LENGTH_MAX]; // specify each scalable layer bitrate
     bool enableLowPower;
     uint32_t targetPercentage;
     uint32_t windowSize; // use for HRD CPB length in ms

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -41,7 +41,8 @@ static void print_help(const char* app)
     printf("   -c <codec: HEVC|AVC|VP8|JPEG>\n");
     printf("   -s <fourcc: I420|NV12|IYUV|YV12>\n");
     printf("   -N <number of frames to encode(camera default 50), useful for camera>\n");
-    printf("   -t <AVC scalability temporal layer number  (default 1)> optional\n");
+    printf("   -t <AVC/VP8 scalability temporal layer number  (default 1), just for CQP mode;\n");
+    printf("       for CBR/VBR mode, the layer number is bitrate number + 1> optional\n");
     printf("   --qp <initial qp> optional\n");
     printf("   --rcmode <CBR|CQP|VBR> optional\n");
     printf("   --target-percnetage <target percentage of bitrate in VBR mode, default 95, range in(50-100)> optional\n");
@@ -62,10 +63,6 @@ static void print_help(const char* app)
     printf("   --priorityid <AVC priority_id of prefix nal unit (default 0)> optional\n");
     printf("   --ow <output width> optional\n");
     printf("   --oh <output height> optional\n");
-    printf("   --btl0 <svc-t layer 0 bitrate: kbps> optional\n");
-    printf("   --btl1 <svc-t layer 1 bitrate: kbps > optional\n");
-    printf("   --btl2 <svc-t layer 2 bitrate: kbps> optional\n");
-    printf("   --btl3 <svc-t layer 3 bitrate: kbps> optional\n");
     printf("   --lowpower <Enable AVC low power mode (default 0, Disabled)> optional\n");
     printf("   --quality-level <encoded video qulity level(default 0), range[%d, %d]> optional\n",
         VIDEO_PARAMS_QUALITYLEVEL_NONE, VIDEO_PARAMS_QUALITYLEVEL_MAX);
@@ -73,6 +70,12 @@ static void print_help(const char* app)
     printf("   --refmode <VP9 Reference frames mode (default 0 last(previous), "
            "gold/alt (previous key frame) | 1 last (previous) gold (one before "
            "last) alt (one before gold)> optional\n");
+    printf("   VP8/AVC SVC-T bitrate settings, the highest layer bitrate is set via \"-b\"; the other lower \n");
+    printf("   layer bitrates are set via the following parameters:\n");
+    printf("   --btl0 <svc-t layer 0 bitrate: kbps> optional\n");
+    printf("   --btl1 <svc-t layer 1 bitrate: kbps > optional\n");
+    printf("   --btl2 <svc-t layer 2 bitrate: kbps> optional\n");
+    printf("   --btl3 <svc-t layer 3 bitrate: kbps> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -283,6 +286,10 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
     if ((para.m_encParams.rcMode == RATE_CONTROL_VBR) && (para.m_encParams.bitRate <= 0)) {
         fprintf(stderr, "please make sure bitrate is positive when VBR mode\n");
         return false;
+    }
+
+    if ((para.m_encParams.rcMode == RATE_CONTROL_CQP) && (para.m_encParams.bitRate > 0)) {
+        para.m_encParams.rcMode = RATE_CONTROL_CBR;
     }
 
     if (!strncmp(para.inputFileName.c_str(), "/dev/video", strlen("/dev/video")) && !para.frameCount)


### PR DESCRIPTION
Yamiencode will generate several files according to the
temporal layer number. That is one file for one layer.
If not in SVC-T mode, only one file was generated as usual.

Signed-off-by: wudping <dongpingx.wu@intel.com>