### PR TITLE
tests/decodeoutput: initialize m_file pointer to NULL

### DIFF
--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -337,6 +337,7 @@ class DecodeOutputMD5 : public DecodeOutputFile {
 public:
     DecodeOutputMD5(const char* outputFile, const char* inputFile, uint32_t fourcc)
         : DecodeOutputFile(outputFile, inputFile, fourcc)
+        , m_file(NULL)
     {
     }
     virtual ~DecodeOutputMD5();


### PR DESCRIPTION
m_file member pointer is not initialized and will get an arbitrary
value.  If that arbitrary value is not 0, then it fools code like
"if(m_file)" into thinking it's ok to use m_file.

Thus, ensure m_file is initialized to NULL in constructor.

Fixes 01org/libyami#743

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>