### PR TITLE
vpx_enc: set time stamp into every frame

### DIFF
--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -259,6 +259,12 @@ const char* EncodeOutputHEVC::getMimeType()
     return YAMI_MIME_HEVC;
 }
 
+void setUint64(uint8_t* header, uint64_t value)
+{
+    uint64_t* h = (uint64_t*)header;
+    *h = value;
+}
+
 void setUint32(uint8_t* header, uint32_t value)
 {
     uint32_t* h = (uint32_t*)header;
@@ -299,6 +305,7 @@ bool EncodeOutputVPX::write(void* data, int size)
     uint8_t header[12];
     memset(header, 0, sizeof(header));
     setUint32(header, size);
+    setUint64(&header[4], m_frameCount);
     if (!EncodeOutput::write(&header, sizeof(header)))
         return false;
     if (!EncodeOutput::write(data, size))


### PR DESCRIPTION
In yamiencode, add time stamp into every frame of vp8/vp9 stream files.

To fix issue [#800](https://github.com/01org/libyami/issues/800)

Signed-off-by: dongping wu <dongpingx.wu@intel.com>