### PR TITLE
tests/decodeinputavformat: use heap-allocated m_packet

### DIFF
--- a/tests/decodeinputavformat.h
+++ b/tests/decodeinputavformat.h
@@ -47,7 +47,7 @@ private:
     AVFormatContext* m_format;
     int m_videoId;
     AVCodecID m_codecId;
-    AVPacket m_packet;
+    AVPacket* m_packet;
     bool m_isEos;
     string m_codecData;
 };


### PR DESCRIPTION
This allows us to migrate away from av_init_packet() which has been
deprecated in recent FFMpeg, making the build fail.

This implementation is somewhat rough, there's probably a way to avoid
reallocating the packet each iteration, but it does the job.